### PR TITLE
Simplify prometheus config generation

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@ require 'json'
 Vagrant.configure('2') do |config|
   playbook_name = ENV['PLAYBOOK']
   inventory = ENV.fetch('INVENTORY', '')
-  host_name = if inventory then "default" else "#{playbook_name}.local" end
+  host_name = if inventory.empty? then "#{playbook_name}.local" else "default" end
   # Check if additional variables are defined
   extra_vars = if ENV['VARS'] then JSON.parse(ENV['VARS']) else {} end
 
@@ -23,9 +23,7 @@ Vagrant.configure('2') do |config|
       ansible.become = true
       ansible.become_user = 'root'
 
-      if inventory
-        ansible.inventory_path = inventory
-      else
+      if inventory.empty?
         ansible.groups = {
           # By convention, our playbooks target a host group with the same name
           # as the playbook
@@ -33,7 +31,10 @@ Vagrant.configure('2') do |config|
           # General groups used by multiple playbooks (potentially)
           'frontends' => [host_name],
         }
+      else
+        ansible.inventory_path = inventory
       end
+      puts ansible.inventory_path
     end
   end
 end

--- a/inventories/chi_uc/hosts
+++ b/inventories/chi_uc/hosts
@@ -39,7 +39,7 @@ admin01
 [prometheus]
 admin01
 
-[node_exporters:children]
+[node_exporter:children]
 controller
 ceph
 storage

--- a/playbooks/prometheus.yml
+++ b/playbooks/prometheus.yml
@@ -4,3 +4,23 @@
     - prometheus
   vars:
     prometheus_alertmanager_slack_api_url: "{{ slack_api_url | default('') }}"
+    # [jca 2018-09-14]
+    # TODO: hard-coding these port numbers isn't great. But, it's pretty hard
+    # to get variables set on remote hosts available within a task like this.
+    # Probably the way forward is to move all the prometheus exporters into
+    # the prometheus role as separate tasks and then use the include_role/tasks_from
+    # to include them here. That way all the information needed for prometheus
+    # would at least be in one place.
+    prometheus_jobs:
+      - name: ceph
+        inventory_group: ceph_exporter
+        port: 9128
+      - name: node
+        inventory_group: node_exporter
+        port: 9100
+      - name: mysql
+        inventory_group: mysql_exporter
+        port: 9104
+      - name: openstack
+        inventory_group: openstack_exporter
+        port: 9103

--- a/roles/prometheus/tasks/main.yml
+++ b/roles/prometheus/tasks/main.yml
@@ -3,108 +3,6 @@
   docker_image:
     name: "{{ prometheus_docker_image }}"
 
-- name: Gather node_exporter hosts.
-  when: groups.node_exporters is defined
-  block:
-    - name: Gather facts from all node_exporters.
-      setup:
-      delegate_to: "{{ item }}"
-      delegate_facts: True
-      with_items: "{{ groups['node_exporters'] }}"
-    - name: Precompute fact for internal exporter ipv4 addresses.
-      set_fact:
-        node_exporters: >
-          {{ { item.inventory_hostname: item.ansible_interfaces
-             | map('regex_replace', '^', 'ansible_')
-             | map('replace', '-', '_')
-             | map('extract', item)
-             | selectattr('ipv4', 'defined')
-             | selectattr('ipv4.address', 'match', '10.*')
-             | map(attribute='ipv4.address')
-             | list
-             | last } | combine(node_exporters | default({})) }}
-      loop: "{{ groups['node_exporters'] | map('extract', hostvars) | list }}"
-      loop_control:
-        label: "{{ item.inventory_hostname }}"
-
-- name: Gather ceph_exporter hosts.
-  when: groups.ceph_exporters is defined
-  block:
-    - name: Gather facts from all ceph_exporter.
-      setup:
-      delegate_to: "{{ item }}"
-      delegate_facts: True
-      with_items: "{{ groups['ceph_exporter'] }}"
-    - name: Precompute fact for internal exporter ipv4 addresses.
-      set_fact:
-        ceph_exporters: >
-          {{ { item.inventory_hostname: item.ansible_interfaces
-             | map('regex_replace', '^', 'ansible_')
-             | map('replace', '-', '_')
-             | map('extract', item)
-             | selectattr('ipv4', 'defined')
-             | selectattr('ipv4.address', 'match', '10.*')
-             | map(attribute='ipv4.address')
-             | list
-             | last
-             | regex_replace('$', ':9128')
-             } | combine(ceph_exporters | default({})) }}
-      loop: "{{ groups['ceph_exporter'] | map('extract', hostvars) | list }}"
-      loop_control:
-        label: "{{ item.inventory_hostname }}"
-
-- name: Gather mysql_exporter hosts.
-  when: groups.mysql_exporters is defined 
-  block:
-    - name: Gather facts from all mysql_exporter.
-      setup:
-      delegate_to: "{{ item }}"
-      delegate_facts: True
-      with_items: "{{ groups['mysql_exporter'] }}"
-    - name: Precompute fact for internal exporter ipv4 addresses.
-      set_fact:
-        mysql_exporters: >
-          {{ { item.inventory_hostname: item.ansible_interfaces
-             | map('regex_replace', '^', 'ansible_')
-             | map('replace', '-', '_')
-             | map('extract', item)
-             | selectattr('ipv4', 'defined')
-             | selectattr('ipv4.address', 'match', '10.*')
-             | map(attribute='ipv4.address')
-             | list
-             | last
-             | regex_replace('$', ':9104')
-             } | combine(mysql_exporters | default({})) }}
-      loop: "{{ groups['mysql_exporter'] | map('extract', hostvars) | list }}"
-      loop_control:
-        label: "{{ item.inventory_hostname }}"
-
-- name: Gather openstack_exporter hosts.
-  when: groups.openstack_exporter is defined
-  block:
-    - name: Gather facts from all openstack_exporter.
-      setup:
-      delegate_to: "{{ item }}"
-      delegate_facts: True
-      with_items: "{{ groups['openstack_exporter'] }}"
-    - name: Precompute fact for internal exporter ipv4 addresses.
-      set_fact:
-        openstack_exporter: >
-          {{ {item.inventory_hostname: item.ansible_interfaces
-             | map('regex_replace', '^', 'ansible_')
-             | map('replace', '-', '_')
-             | map('extract', item)
-             | selectattr('ipv4', 'defined')
-             | selectattr('ipv4.address', 'match', '10.*')
-             | map(attribute='ipv4.address')
-             | list
-             | last
-             | regex_replace('$', ':9103')
-             } | combine(openstack_exporter | default({})) }}
-      loop: "{{ groups['openstack_exporter'] | map('extract', hostvars) | list }}"
-      loop_control:
-        label: "{{ item.inventory_hostname }}"
-
 - name: Create Prometheus configuration directory.
   file:
     path: "{{ prometheus_config_dir }}"
@@ -112,6 +10,26 @@
 
 - name: Configure Prometheus.
   block:
+    - name: Get network facts for all nodes.
+      setup:
+        gather_subset: network
+      delegate_to: "{{ item }}"
+      delegate_facts: True
+      loop: "{{ groups.all }}"
+    - name: Set fact for internal host addresses.
+      set_fact:
+        ansible_internal_ipv4_addresses: >
+          {{ { item.inventory_hostname: item.ansible_interfaces
+             | map('regex_replace', '^', 'ansible_')
+             | map('replace', '-', '_')
+             | map('extract', item)
+             | selectattr('ipv4', 'defined')
+             | selectattr('ipv4.address', 'match', '10.*')
+             | map(attribute='ipv4.address')
+             | list | last} | combine(ansible_internal_ipv4_addresses | default({})) }}
+      loop: "{{ groups.all | map('extract', hostvars) | list }}"
+      loop_control:
+        label: "{{ item.inventory_hostname }}"
     - name: Create config directory.
       file:
         path: "{{ prometheus_config_dir }}"

--- a/roles/prometheus/templates/prometheus.yml.j2
+++ b/roles/prometheus/templates/prometheus.yml.j2
@@ -14,45 +14,16 @@ global:
 rule_files:
   - "/etc/prometheus/*-rules.yml"
 
-# A scrape configuration containing exactly one endpoint to scrape:
-# Here it's Prometheus itself.
 scrape_configs:
   - job_name: 'prometheus'
     static_configs:
     - targets: ['localhost:9090']
-{% if node_exporters is defined %}
-{% for host in node_exporters %}
-  - job_name: '{{ host }}-node'
+{% for job in prometheus_jobs if groups[job.inventory_group] is defined %}
+  - job_name: '{{ job.name }}'
     static_configs:
-      - targets: ['{{ node_exporters[host] }}:9100']
+{% for host in groups[job.inventory_group] %}
+      - targets: ['{{ ansible_internal_ipv4_addresses[host] }}:{{ job.port }}']
         labels:
           hostname: '{{ host }}'
 {% endfor %}
-{% endif %}
-{% if ceph_exporters is defined %}
-{% for host in ceph_exporters %}
-  - job_name: '{{ host }}-ceph'
-    static_configs:
-      - targets: ['{{ ceph_exporters[host] }}']
-        labels:
-          hostname: '{{ host }}'
 {% endfor %}
-{% endif %}
-{% if mysql_exporter is defined %}
-{% for host in mysql_exporters %}
-  - job_name: '{{ host }}-mysql'
-    static_configs:
-      - targets: ['{{ mysql_exporters[host] }}']
-        labels:
-          hostname: '{{ host }}'
-{% endfor %}
-{% endif %}
-{% if openstack_exporter is defined %}
-{% for host in openstack_exporter %}
-  - job_name: '{{ host }}-openstack'
-    static_configs:
-      - targets: ['{{ openstack_exporter[host] }}']
-        labels:
-          hostname: '{{ host }}'
-{% endfor %}
-{% endif %}


### PR DESCRIPTION
Currently we have a lot of boilerplate when setting up prometheus static
configs. This simplifies that a bunch by pulling the internal addresses
out to a fact first, then creating a 'jobs' structure that associates a
scrape job with an inventory group. The template references ansible
variables directly instead of relying on some magic vars being placed on
the template context.