### PR TITLE
Added extended prometheus-openstack-exporter image to playbooks.

### DIFF
--- a/roles/openstack_exporter/defaults/main.yml
+++ b/roles/openstack_exporter/defaults/main.yml
@@ -1,11 +1,12 @@
 ---
 openstack_prometheus_exporter_port: 9103
-openstack_prometheus_exporter_docker_image: rakeshpatnaik/prometheus-openstack-exporter:v0.2
+openstack_prometheus_exporter_docker_image: docker.chameleoncloud.org/prometheus-openstack-exporter:latest
 openstack_prometheus_exporter_service_name: prometheus-openstack-exporter
 openstack_prometheus_exporter_config_path: /etc/prometheus/openstack-exporter
 openstack_prometheus_exporter_project_name: openstack
 openstack_prometheus_exporter_username: admin
 openstack_prometheus_exporter_user_domain_name: default
+openstack_prometheus_exporter_project_domain_name: default
 openstack_prometheus_exporter_no_cache: true
 
 openstack_prometheus_exporter_timeout: 20

--- a/roles/openstack_exporter/templates/prometheus_exporter.env.list.j2
+++ b/roles/openstack_exporter/templates/prometheus_exporter.env.list.j2
@@ -4,6 +4,7 @@ OS_PASSWORD={{ openstack_prometheus_exporter_password}}
 OS_PROJECT_NAME={{ openstack_prometheus_exporter_project_name }}
 OS_USERNAME={{ openstack_prometheus_exporter_username }}
 OS_USER_DOMAIN_NAME={{ openstack_prometheus_exporter_user_domain_name }}
+OS_PROJECT_DOMAIN_NAME={{ openstack_prometheus_exporter_project_domain_name }}
 OS_REGION_NAME={{ openstack_prometheus_exporter_region_name }}
 OS_NO_CACHE={{ openstack_prometheus_exporter_no_cache }}
 TIMEOUT_SECONDS={{ openstack_prometheus_exporter_timeout }}


### PR DESCRIPTION
This just replaces the public docker image we were using with our own image, and modifies one environment variable.

Extended OpenStackExporter:
https://github.com/ChameleonCloud/prometheus-openstack-exporter