### PR TITLE
Add Apache exporter

### DIFF
--- a/environments/chi_uc/inventory/hosts
+++ b/environments/chi_uc/inventory/hosts
@@ -707,6 +707,9 @@ storage
 [prometheus-alertmanager:children]
 monitoring
 
+[prometheus-apache-exporter:children]
+frontends
+
 [prometheus-jupyterhub-exporter:children]
 jupyterhub
 

--- a/playbooks/prometheus.yml
+++ b/playbooks/prometheus.yml
@@ -1,6 +1,7 @@
 ---
 - hosts:
     - prometheus
+    - prometheus-apache-exporter
     - prometheus-ceph-exporter
     - prometheus-mysqld-exporter
     - prometheus-openstack-exporter
@@ -9,6 +10,7 @@
 
 - hosts:
     - prometheus
+    - prometheus-apache-exporter
     - prometheus-ceph-exporter
     - prometheus-jupyterhub-exporter
     - prometheus-mysqld-exporter

--- a/roles/prometheus/defaults/main.yml
+++ b/roles/prometheus/defaults/main.yml
@@ -34,6 +34,12 @@ prometheus_services:
     volumes:
       - "alertmanager-data:/alertmanager"
       - "/etc/alertmanager:/etc/alertmanager"
+  apache-exporter:
+    service_name: prometheus_apache_exporter
+    image: docker.chameleoncloud.org/apache_exporter:77c9bc9
+    group: prometheus-apache-exporter
+    port: 9117
+    scrape_target: yes
   ceph-exporter:
     service_name: prometheus_ceph_exporter
     image: digitalocean/ceph_exporter:2.0.0-luminous

--- a/roles/prometheus/defaults/main.yml
+++ b/roles/prometheus/defaults/main.yml
@@ -39,6 +39,8 @@ prometheus_services:
     image: docker.chameleoncloud.org/apache_exporter:77c9bc9
     group: prometheus-apache-exporter
     port: 9117
+    service_args:
+      - "-scrape_uri http://{{ ansible_internal_ipv4_addresses[inventory_hostname] }}/server-status?auto"
     scrape_target: yes
   ceph-exporter:
     service_name: prometheus_ceph_exporter


### PR DESCRIPTION
Adds some metrics so we can see usage on the Apache proxies. Less useful over time, useful during a migration though.

Doesn't come with all the metrics I thought it would. Though, seems like sometimes a restart of httpd needs to be done for all the new ones to come through.