### PR TITLE
Remove vlan ranges for 1 exogeni and 60 physnet1 at UC and TACC

### DIFF
--- a/environments/chi_tacc/globals.yml
+++ b/environments/chi_tacc/globals.yml
@@ -161,7 +161,7 @@ neutron_notification_topics:
     enabled: "yes"
 neutron_type_drivers: flat,vlan
 neutron_tenant_network_types: vlan
-neutron_network_vlan_ranges: scinet:1999:1999,physnet1:2000:2010,physnet1:2013:2020,physnet1:2023:2499,exogeni:3500:3500,exogeni:3504:3505,exogeni:3507:3508
+neutron_network_vlan_ranges: scinet:1999:1999,physnet1:2000:2010,physnet1:2013:2020,physnet1:2023:2439,exogeni:3500:3500,exogeni:3505:3505,exogeni:3507:3508
 neutron_ml2_generic_switch_configs:
   - name: roc-be24-sw1 # m01
     device_type: netmiko_dell_force10

--- a/environments/chi_uc/globals.yml
+++ b/environments/chi_uc/globals.yml
@@ -165,7 +165,7 @@ neutron_tenant_network_types: vlan
 neutron_bridge_name: br-em1,br-ex,br-exogeni
 neutron_external_interface: em1,em2,br-em1
 neutron_ovs_bridge_mappings: physnet1:br-em1,public:br-ex,exogeni:br-exogeni
-neutron_network_vlan_ranges: physnet1:3010:3288,exogeni:3290:3290,exogeni:3299:3299
+neutron_network_vlan_ranges: physnet1:3010:3228,exogeni:3290:3290,exogeni:3299:3299
 neutron_ml2_generic_switch_configs:
   - name: Chameleon-Cloud
     device_type: netmiko_dell_force10


### PR DESCRIPTION
Verified neither of the network segments removed are in use. Should be able to reclaim one exogeni segment at TACC and add the range of 60 vlan tags to blazar for each site.