### PR TITLE
Add support for post-deploy step

### DIFF
--- a/cc-ansible
+++ b/cc-ansible
@@ -167,6 +167,8 @@ kolla_args+=(--inventory="$CC_ANSIBLE_SITE/inventory")
 kolla_args+=(--key="$CC_ANSIBLE_VAULT_PASSWORD")
 kolla_args+=(--passwords="$CC_ANSIBLE_SITE/passwords.yml")
 kolla_args+=(--extra node_custom_config="$DIR/kolla/node_custom_config")
+kolla_args+=(--extra post_deploy_custom_play="$DIR/playbooks/post_deploy.yml")
+kolla_args+=(--extra cc_ansible_site_dir="$CC_ANSIBLE_SITE")
 # Override python interpreter to point to virtualenv (but only if we're
 # not performing the bootstrap, which is responsible for setting up the
 # virtualenv in the first place!)

--- a/playbooks/post_deploy.yml
+++ b/playbooks/post_deploy.yml
@@ -1,0 +1,140 @@
+---
+- hosts: deployment
+  tasks:
+  - set_fact:
+      glance_images_tmp: "/tmp"
+      glance_images:
+      - name: pxe_deploy_kernel
+        container_format: aki
+        disk_format: aki
+        url: "https://tarballs.openstack.org/ironic-python-agent/coreos/files/coreos_production_pxe-stable-{{ openstack_release }}.vmlinuz"
+      - name: pxe_deploy_ramdisk
+        container_format: aki
+        disk_format: aki
+        url: "https://tarballs.openstack.org/ironic-python-agent/coreos/files/coreos_production_pxe_image-oem-stable-{{ openstack_release }}.cpio.gz"
+  - name: Check state of Glance images.
+    os_image_facts:
+    when: enable_ironic | bool
+  - name: Download source Glance images.
+    get_url:
+      url: "{{ item.url }}"
+      dest: "{{ glance_images_tmp }}/{{ item.name }}"
+    loop: "{{ glance_images }}"
+    loop_control:
+      label: "{{ item.name }}"
+    when: enable_ironic | bool and
+         (openstack_image | selectattr('name', 'match', item.name)) | list | length < 1
+  - name: Create Glance images.
+    os_image:
+      state: present
+      name: "{{ item.name }}"
+      is_public: yes
+      interface: admin
+      container_format: "{{ item.container_format }}"
+      disk_format: "{{ item.disk_format }}"
+      filename: "{{ glance_images_tmp }}/{{ item.name }}"
+    loop: "{{ glance_images }}"
+    loop_control:
+      label: "{{ item.name }}"
+    when: enable_ironic | bool
+  - name: Create baremetal flavor.
+    os_nova_flavor:
+      state: present
+      name: baremetal
+      interface: admin
+      is_public: yes
+      extra_specs:
+        "resources:CUSTOM_BAREMETAL": 1
+        "resources:VCPU": 0
+        "resources:MEMORY_MB": 0
+        "resources:DISK_GB": 0
+      # Needs to be greater than largest expected disk image, yet smaller than
+      # actual node capacity; we guess a low value.
+      disk: 20
+      ram: 0
+      vcpus: 0
+    when: enable_ironic | bool
+  - name: Create provisioning network.
+    local_action:
+      module: os_network
+      name: "{{ ironic_provisioning_network }}"
+      region_name: "{{ openstack_region_name }}"
+      provider_network_type: vlan
+      provider_segmentation_id: "{{ ironic_provisioning_network_vlan }}"
+      provider_physical_network: physnet1
+      state: present
+    when: enable_ironic | bool
+  - name: Create provisioning subnet.
+    local_action:
+      module: os_subnet
+      network_name: "{{ ironic_provisioning_network }}"
+      name: "{{ ironic_provisioning_network }}-subnet"
+      cidr: "{{ ironic_provisioning_network_cidr }}"
+      allocation_pool_start: "{{ ironic_provisioning_network_cidr | next_nth_usable(2) }}"
+      allocation_pool_end: "{{ ironic_provisioning_network_cidr | ipaddr('last_usable') }}"
+      host_routes:
+      - destination: "{{ kolla_internal_vip_address }}/32"
+        nexthop: "{{ ironic_provisioning_network_gateway }}"
+    when: enable_ironic | bool
+  # Blazar-specific initialization
+  - name: Create freepool aggregate.
+    os_nova_host_aggregate:
+      state: present
+      name: freepool
+    when: enable_blazar | bool
+
+  - name: Check if site-specific post_deploy playbook exists.
+    stat:
+      path: "{{ cc_ansible_site_dir }}/post_deploy.yml"
+    register: post_deploy_result
+  - name: Set fact for site-specific post_deploy playbook
+    set_fact:
+      post_deploy_path: "{{ cc_ansible_site_dir }}/post_deploy.yml"
+    delegate_to: localhost
+    delegate_facts: yes
+    when: post_deploy_result.stat.exists
+
+- hosts: control
+  pre_tasks:
+  - name: Set facts for Ironic interfaces.
+    block:
+    - set_fact:
+        ironic_interfaces:
+        - device: "{{ network_interface | replace('_', '-') }}.{{ ironic_provisioning_network_vlan }}"
+          bootproto: static
+          address: "{{ ironic_provisioning_network_gateway }}"
+          netmask: "{{ ironic_provisioning_network_cidr | ipaddr('netmask') }}"
+    when: enable_ironic | bool and
+          ironic_provisioning_network_cidr is defined
+  - name: Set facts for Corsa interfaces.
+    block:
+    - set_fact:
+        corsa_nat_interfaces:
+        - device: "{{ network_interface | replace('_', '-') }}.{{ corsa_nat_network_vlan }}"
+          bootproto: static
+          address: "{{ corsa_nat_network_gateway }}"
+          netmask: "{{ corsa_nat_network_cidr | ipaddr('netmask') }}"
+    when: corsa_nat_network_cidr is defined
+  roles:
+  - role: michaelrigart.interfaces
+    interfaces_ether_interfaces: >
+      {{ (ironic_interfaces | default([])) +
+         (corsa_nat_interfaces | default([])) }}
+    become: True
+  tasks:
+  - name: Set fact for Corsa switches.
+    set_fact:
+      corsa_switches: "{{ switch_configs | selectattr('device_type', 'match', '^corsa') | list }}"
+  - name: Allow NAT for Corsa switches.
+    iptables:
+      table: nat
+      chain: POSTROUTING
+      source: "{{ item.nat_ip }}"
+      out_interface: "{{ kolla_external_vip_interface | replace('_', '-') }}"
+      jump: MASQUERADE
+      comment: "NAT for {{ item.name }}"
+    become: yes
+    loop: "{{ corsa_switches }}"
+    when: corsa_switches | length > 0
+
+- import_playbook: "{{ cc_ansible_site_dir }}/post_deploy.yml"

--- a/roles/ansible/tasks/main.yml
+++ b/roles/ansible/tasks/main.yml
@@ -17,3 +17,5 @@
         # For os_user module
         - openstacksdk
         - shade
+        # For ipaddr filter
+        - netaddr


### PR DESCRIPTION
There is a generic post-deploy step which runs for any site, when you
run `./cc-ansible post-deploy` (this is also a KA step). It will first
invoke what KA would normally do, then call an extra play of the user's
choice (we set this to be playbooks/post_deploy.yml). That playbook
additionally supports chain-loading a site-specific playbook.

The generic playbook will set up the Ironic provisioning network, the
baremetal flavor, and other things needed for Ironic to work. It also
sets up NAT rules for Corsa switches (if any). It also ensures that the
latest ramdisk/kernel are available as images.