### PR TITLE
[ironic] increase neutron timeout from default 30 seconds to 900 seconds

### DIFF
--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -52,6 +52,7 @@ hammers_openstack_project_name: "{{ keystone_admin_project }}"
 # HAProxy
 enable_haproxy: yes
 kolla_enable_tls_external: yes
+haproxy_listen_neutron_server_extra: ["timeout server 15m"]
 
 # Heat
 enable_heat: yes

--- a/kolla/node_custom_config/ironic.conf
+++ b/kolla/node_custom_config/ironic.conf
@@ -17,6 +17,7 @@ default_boot_option = local
 [neutron]
 cleaning_network = "{{ ironic_cleaning_network }}"
 provisioning_network = "{{ ironic_provisioning_network }}"
+timeout = 900
 
 [oslo_messaging_notifications]
 driver = messagingv2


### PR DESCRIPTION
When launching a large amount of nodes, typically some will fail provisioning. The error is due to the timeout when trying to create the network port.