### PR TITLE
Add Mitogen for faster execution

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -14,3 +14,6 @@ fact_caching_connection = .facts
 # dictionary, without overriding everything.
 hash_behaviour = merge
 library = ./playbooks/library
+# Use Mitogen for a higher-performance task execution strategy
+strategy_plugins = ./venv/lib/mitogen-latest/ansible_mitogen/plugins/strategy
+strategy = mitogen_linear

--- a/cc-ansible
+++ b/cc-ansible
@@ -162,6 +162,17 @@ if [[ "$CHECK_UPDATES" == "yes" || "$FORCE_UPDATES" == "yes" ]]; then
   if ! pip freeze | grep -q kolla-ansible; then
     (cd kolla/kolla-ansible; python setup.py install; pip install -r requirements.txt)
   fi
+
+  # Update Mitogen
+  MITOGEN_VERSION=0.2.8
+  MITOGEN_TARBALL=/tmp/mitogen.tar.gz
+  MITOGEN_INSTALL_DIR="$DIR/venv/lib/mitogen-$MITOGEN_VERSION"
+  if [[ ! -d "$MITOGEN_INSTALL_DIR" ]]; then
+    curl -L -o "$MITOGEN_TARBALL" "https://github.com/dw/mitogen/archive/v$MITOGEN_VERSION.tar.gz" \
+      && tar -xf "$MITOGEN_TARBALL" -C "$(dirname $MITOGEN_INSTALL_DIR)" \
+      && rm -f "$MITOGEN_TARBALL"
+  fi
+  ln -sf "$MITOGEN_INSTALL_DIR" "$DIR/venv/lib/mitogen-latest"
 fi
 
 # Handle subcommands


### PR DESCRIPTION
Mitogen[1] is a drop-in replacement for the default Ansible execution
strategy. Ansible by default will re-establish new SSH connections for
every step of a flow, which adds a lot of overhead. Our plays don't see
the normally-advertised 5-7x speedup, but it does improve things by
about 50%. Plays/roles that have less steps requiring expsensive API
calls benefit more.

[1]: https://networkgenomics.com/ansible/