### PR TITLE
[jupyterhub] Store home directories on Ceph

### DIFF
--- a/roles/jupyterhub/defaults/main.yml
+++ b/roles/jupyterhub/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 jupyterhub_config_path: /etc/jupyterhub
 jupyterhub_crypt_key: ''
-jupyterhub_docker_image: docker.chameleoncloud.org/jupyterhub:dbf7a23
+jupyterhub_docker_image: docker.chameleoncloud.org/jupyterhub:f30a3f3
 jupyterhub_docker_network: jupyterhub
 jupyterhub_docker_network_subnet: 172.18.20.0/24
 jupyterhub_docker_volume_name: jupyterhub-storage

--- a/roles/jupyterhub/defaults/main.yml
+++ b/roles/jupyterhub/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 jupyterhub_config_path: /etc/jupyterhub
 jupyterhub_crypt_key: ''
-jupyterhub_docker_image: docker.chameleoncloud.org/jupyterhub:f30a3f3
+jupyterhub_docker_image: docker.chameleoncloud.org/jupyterhub:dbf7a23
 jupyterhub_docker_network: jupyterhub
 jupyterhub_docker_network_subnet: 172.18.20.0/24
 jupyterhub_docker_volume_name: jupyterhub-storage

--- a/roles/jupyterhub/defaults/main.yml
+++ b/roles/jupyterhub/defaults/main.yml
@@ -10,6 +10,12 @@ jupyterhub_port: 8075 # Just needs to be something that doesn't conflict
 jupyterhub_service_name: jupyterhub
 jupyterhub_user: jupyterhub
 
+jupyterhub_enable_ceph: no
+jupyterhub_ceph_cluster: ceph
+jupyterhub_ceph_client: client.jupyter
+jupyterhub_ceph_pool: jupyter-volumes
+jupyterhub_ceph_docker_volume_driver: wetopi/rbd
+
 jupyterhub_db_service_name: jupyterhub-db
 jupyterhub_db_docker_image: mariadb:10.2
 jupyterhub_db_docker_volume_name: jupyterhub-db-storage

--- a/roles/jupyterhub/defaults/main.yml
+++ b/roles/jupyterhub/defaults/main.yml
@@ -14,7 +14,8 @@ jupyterhub_enable_ceph: no
 jupyterhub_ceph_cluster: ceph
 jupyterhub_ceph_client: client.jupyter
 jupyterhub_ceph_pool: jupyter-volumes
-jupyterhub_ceph_docker_volume_driver: wetopi/rbd
+jupyterhub_ceph_docker_volume_driver: docker.chameleoncloud.org/wetopi/rbd:latest
+jupyterhub_ceph_docker_volume_driver_alias: rbd
 
 jupyterhub_db_service_name: jupyterhub-db
 jupyterhub_db_docker_image: mariadb:10.2

--- a/roles/jupyterhub/defaults/main.yml
+++ b/roles/jupyterhub/defaults/main.yml
@@ -25,5 +25,5 @@ jupyterhub_db_user: jupyterhub
 jupyterhub_db_password: ''
 jupyterhub_db_db: jupyterhub
 
-jupyterhub_notebook_docker_image: docker.chameleoncloud.org/jupyterhub-user:a7ed8a8
+jupyterhub_notebook_docker_image: docker.chameleoncloud.org/jupyterhub-user:c3377d0
 jupyterhub_notebook_workdir: /work

--- a/roles/jupyterhub/tasks/ceph.yml
+++ b/roles/jupyterhub/tasks/ceph.yml
@@ -1,4 +1,9 @@
 ---
+- name: Create Ceph configuration directory.
+  file:
+    path: /etc/ceph
+    state: directory
+
 - name: Copy global Ceph configuration.
   block:
     - slurp:
@@ -15,12 +20,13 @@
       register: ceph_client_keyring
       delegate_to: "{{ groups.ceph[0] }}"
     - copy:
-        content: "{{ ceph_client_keyring.output }}"
+        content: "{{ ceph_client_keyring.stdout }}"
         dest: "/etc/ceph/ceph.{{ jupyterhub_ceph_client }}.keyring"
 
 - name: Install Docker RBD volume plugin.
-  command: <
+  command: >
     docker plugin install "{{ jupyterhub_ceph_docker_volume_driver }}" \
+      --grant-all-permissions \
       --alias="{{ jupyterhub_ceph_docker_volume_driver }}" \
       LOG_LEVEL=1 \
       RBD_CONF_POOL="{{ jupyterhub_ceph_pool }}" \

--- a/roles/jupyterhub/tasks/ceph.yml
+++ b/roles/jupyterhub/tasks/ceph.yml
@@ -1,9 +1,13 @@
 ---
 - name: Copy global Ceph configuration.
-  synchronize:
-    src: /etc/ceph/ceph.conf
-    dest: /etc/ceph/ceph.conf
-  delegate_to: "{{ groups.ceph[0] }}"
+  block:
+    - slurp:
+        src: /etc/ceph/ceph.conf
+      delegate_to: "{{ groups.ceph[0] }}"
+      register: ceph_conf
+    - copy:
+        content: "{{ ceph_conf['content'] | b64decode }}"
+        dest: /etc/ceph/ceph.conf
 
 - name: Copy Ceph client keyring.
   block:

--- a/roles/jupyterhub/tasks/ceph.yml
+++ b/roles/jupyterhub/tasks/ceph.yml
@@ -27,7 +27,7 @@
   command: >
     docker plugin install "{{ jupyterhub_ceph_docker_volume_driver }}" \
       --grant-all-permissions \
-      --alias="{{ jupyterhub_ceph_docker_volume_driver }}" \
+      --alias="{{ jupyterhub_ceph_docker_volume_driver_alias }}" \
       LOG_LEVEL=1 \
       RBD_CONF_POOL="{{ jupyterhub_ceph_pool }}" \
       RBD_CONF_CLUSTER="{{ jupyterhub_ceph_cluster }}" \

--- a/roles/jupyterhub/tasks/ceph.yml
+++ b/roles/jupyterhub/tasks/ceph.yml
@@ -1,0 +1,24 @@
+---
+- name: Copy global Ceph configuration.
+  synchronize:
+    src: /etc/ceph/ceph.conf
+    dest: /etc/ceph/ceph.conf
+  delegate_to: "{{ groups.ceph[0] }}"
+
+- name: Copy Ceph client keyring.
+  block:
+    - command: "ceph auth get {{ jupyterhub_ceph_client }}"
+      register: ceph_client_keyring
+      delegate_to: "{{ groups.ceph[0] }}"
+    - copy:
+        content: "{{ ceph_client_keyring.output }}"
+        dest: "/etc/ceph/ceph.{{ jupyterhub_ceph_client }}.keyring"
+
+- name: Install Docker RBD volume plugin.
+  command: <
+    docker plugin install "{{ jupyterhub_ceph_docker_volume_driver }}" \
+      --alias="{{ jupyterhub_ceph_docker_volume_driver }}" \
+      LOG_LEVEL=1 \
+      RBD_CONF_POOL="{{ jupyterhub_ceph_pool }}" \
+      RBD_CONF_CLUSTER="{{ jupyterhub_ceph_cluster }}" \
+      RBD_CONF_KEYRING_USER="{{ jupyterhub_ceph_client }}"

--- a/roles/jupyterhub/tasks/main.yml
+++ b/roles/jupyterhub/tasks/main.yml
@@ -51,6 +51,9 @@
   tags:
     - configuration
 
+- include_tasks: ceph.yml
+  when: jupyterhub_enable_ceph | bool
+
 - name: Enable JupyterHub services on boot.
   systemd:
     service: "{{ item }}"

--- a/roles/jupyterhub/templates/jupyterhub.env.j2
+++ b/roles/jupyterhub/templates/jupyterhub.env.j2
@@ -5,6 +5,7 @@ DOCKER_NOTEBOOK_DIR={{ jupyterhub_notebook_workdir }}
 DOCKER_NOTEBOOK_IMAGE={{ jupyterhub_notebook_docker_image }}
 {% if jupyterhub_enable_ceph | bool %}
 DOCKER_VOLUME_DRIVER={{ jupyterhub_ceph_docker_volume_driver }}
+DOCKER_VOLUME_DRIVER_OPTS=size=1024,order=22
 {% endif %}
 
 JUPYTERHUB_CRYPT_KEY={{ jupyterhub_crypt_key }}

--- a/roles/jupyterhub/templates/jupyterhub.env.j2
+++ b/roles/jupyterhub/templates/jupyterhub.env.j2
@@ -3,7 +3,12 @@ OS_AUTH_URL={{ keystone_public_url }}/v3
 DOCKER_NETWORK_NAME={{ jupyterhub_docker_network }}
 DOCKER_NOTEBOOK_DIR={{ jupyterhub_notebook_workdir }}
 DOCKER_NOTEBOOK_IMAGE={{ jupyterhub_notebook_docker_image }}
+{% if jupyterhub_enable_ceph | bool %}
+DOCKER_VOLUME_DRIVER={{ jupyterhub_ceph_docker_volume_driver }}
+{% endif %}
+
 JUPYTERHUB_CRYPT_KEY={{ jupyterhub_crypt_key }}
+
 MYSQL_HOST={{ jupyterhub_db_service_name }}
 MYSQL_USER={{ jupyterhub_db_user }}
 MYSQL_PASSWORD={{ jupyterhub_db_password }}

--- a/roles/jupyterhub/templates/jupyterhub.env.j2
+++ b/roles/jupyterhub/templates/jupyterhub.env.j2
@@ -4,7 +4,7 @@ DOCKER_NETWORK_NAME={{ jupyterhub_docker_network }}
 DOCKER_NOTEBOOK_DIR={{ jupyterhub_notebook_workdir }}
 DOCKER_NOTEBOOK_IMAGE={{ jupyterhub_notebook_docker_image }}
 {% if jupyterhub_enable_ceph | bool %}
-DOCKER_VOLUME_DRIVER={{ jupyterhub_ceph_docker_volume_driver }}
+DOCKER_VOLUME_DRIVER={{ jupyterhub_ceph_docker_volume_driver_alias }}
 DOCKER_VOLUME_DRIVER_OPTS=size=1024,order=22
 {% endif %}
 


### PR DESCRIPTION
This adds support for storing user home directories on Ceph. This is done by installing a custom Docker plugin that can map volumes to RBD images.