### PR TITLE
[docker_registry] Add GC script

### DIFF
--- a/roles/docker_registry/defaults/main.yml
+++ b/roles/docker_registry/defaults/main.yml
@@ -5,7 +5,8 @@ docker_registry_hostname: docker.chameleoncloud.org
 docker_registry_port: 5000
 docker_registry_debug_port: 5001
 docker_registry_service_name: docker_registry
-
+docker_registry_docker_network: registry
+docker_registry_docker_network_subnet: 172.18.5.0/29
 docker_registry_readonly_user: registry
 docker_registry_readonly_password: ''
 

--- a/roles/docker_registry/tasks/main.yml
+++ b/roles/docker_registry/tasks/main.yml
@@ -11,11 +11,22 @@
     name: "{{ docker_registry_swift_username }}"
     password: "{{ docker_registry_swift_password }}"
     region_name: "{{ keystone_primary_region_name }}"
+    auth: "{{ openstack_auth }}"
+    # NOTE(jca 2019-10-14):
+    # Need to explicitly set this to empty to avoid
+    # buggy auto-detect region attempts by this module
+    cloud: ""
   no_log: True
   vars:
     # Ensure when we run this on the ansible host, we use the Virtualenv
     # (which should already be set up.)
     ansible_python_interpreter: "{{ ansible_python_interpreter }}"
+
+- name: Create Docker network.
+  docker_network:
+    name: "{{ docker_registry_docker_network }}"
+    ipam_config:
+      - subnet: "{{ docker_registry_docker_network_subnet }}"
 
 - name: Configure Docker Registry.
   block:
@@ -23,12 +34,25 @@
       file:
         path: "{{ docker_registry_config_path }}"
         state: directory
-    - name: Create Docker Registry config.
+    - name: Create Docker Registry production config.
       template:
         src: config.yml.j2
-        dest: "{{ docker_registry_config_path }}/config.yml"
+        dest: "{{ docker_registry_config_path }}/config.prod.yml"
+        mode: '0640'
       notify:
         - restart docker registry
+    - name: Create Docker Registry maintenance config.
+      template:
+        src: config.yml.j2
+        dest: "{{ docker_registry_config_path }}/config.maintenance.yml"
+        mode: '0640'
+      vars:
+        maintenance: yes
+    - name: Create symbolic link for production config.
+      file:
+        src: "config.prod.yml"
+        dest: "{{ docker_registry_config_path }}/config.yml"
+        state: link
     - name: Configure Docker Registry systemd service.
       template:
         src: docker_registry.service.j2
@@ -45,3 +69,21 @@
     daemon_reload: yes
     state: started
     enabled: yes
+
+- name: Install garbage collection script.
+  template:
+    src: docker-registry-gc.sh.j2
+    dest: /usr/local/sbin/docker-registry-gc
+    mode: '0750'
+
+- name: Install cron job to automatically call garbage collection.
+  cron:
+    # Every tuesday at 5:00am - put it in the middle of the week
+    # so issues can be caught during week.
+    name: Docker registry periodic GC
+    minute: '0'
+    hour: '5'
+    day: '*'
+    month: '*'
+    weekday: '2'
+    job: /usr/local/sbin/docker-registry-gc | logger -t docker-registry-gc

--- a/roles/docker_registry/templates/config.yml.j2
+++ b/roles/docker_registry/templates/config.yml.j2
@@ -15,10 +15,17 @@ storage:
     region: {{ docker_registry_swift_region }}
     container: {{ docker_registry_swift_containername }}
     endpointtype: {{ docker_registry_swift_endpointtype }}
+  delete:
+    enabled: true
+{% if maintenance is defined and maintenance | bool %}
+  maintenance:
+    readonly:
+      enabled: true
+{% endif %}
 http:
   addr: :5000
   debug:
-    addr: localhost:5001
+    addr: :5001
   headers:
     X-Content-Type-Options: [nosniff]
 health:

--- a/roles/docker_registry/templates/docker-registry-gc.sh.j2
+++ b/roles/docker_registry/templates/docker-registry-gc.sh.j2
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -e -u
+
+echo "Marking tags older than most recent 10 for deletion ..."
+docker run --network {{ docker_registry_docker_network }} --rm anoxis/registry-cli \
+  -r http://registry:5000 --delete --num 10
+
+# Perform deletion. Need to put registry into read-only mode
+# to avoid corruption.
+
+pushd {{ docker_registry_config_path }}
+
+echo "Restarting registry in maintenance mode ..."
+ln -sf config.maintenance.yml config.yml
+systemctl restart {{ docker_registry_service_name }}
+
+sleep 2
+
+echo "Performing full mark-sweep GC ..."
+docker exec {{ docker_registry_service_name }} \
+  bin/registry garbage-collect /etc/docker/registry/config.yml
+
+# Restoring original config
+ln -sf config.prod.yml config.yml
+echo "Restarting registry in production mode ..."
+systemctl restart {{ docker_registry_service_name }}

--- a/roles/docker_registry/templates/docker_registry.service.j2
+++ b/roles/docker_registry/templates/docker_registry.service.j2
@@ -5,10 +5,11 @@ After=docker.service
 [Service]
 Restart=always
 ExecStart=/bin/docker run --name=%N \
-                          --net=host \
-                          -p {{ docker_registry_port }}:5000 \
-                          -p {{ docker_registry_debug_port }}:5001 \
-                          -v {{ docker_registry_config_path }}/config.yml:/etc/docker/registry/config.yml:ro \
+                          -p {{ api_interface_address }}:{{ docker_registry_port }}:5000 \
+                          -p 127.0.0.1:{{ docker_registry_debug_port }}:5001 \
+                          --network {{ docker_registry_docker_network }} \
+                          --network-alias registry \
+                          -v {{ docker_registry_config_path }}:/etc/docker/registry:ro \
                           {{ docker_registry_image }}
 ExecStop=/bin/docker stop -t 2 %N
 ExecStopPost=/bin/docker rm -f %N

--- a/roles/jupyterhub/tasks/main.yml
+++ b/roles/jupyterhub/tasks/main.yml
@@ -13,8 +13,8 @@
 - name: Create Docker network.
   docker_network:
     name: "{{ jupyterhub_docker_network }}"
-    ipam_options:
-      subnet: "{{ jupyterhub_docker_network_subnet }}"
+    ipam_config:
+      - subnet: "{{ jupyterhub_docker_network_subnet }}"
 
 - name: Configure JupyterHub.
   block:

--- a/roles/precis/tasks/main.yml
+++ b/roles/precis/tasks/main.yml
@@ -62,8 +62,8 @@
 - name: Create Docker network.
   docker_network:
     name: "{{ precis_docker_network }}"
-    ipam_options:
-      subnet: "{{ precis_docker_network_subnet }}"
+    ipam_config:
+      - subnet: "{{ precis_docker_network_subnet }}"
     state: present
   when: precis_docker_network != "host"
 

--- a/roles/prometheus/tasks/main.yml
+++ b/roles/prometheus/tasks/main.yml
@@ -6,8 +6,8 @@
   docker_network:
     name: "{{ prometheus_docker_network_name }}"
     driver: bridge
-    ipam_options:
-      subnet: "{{ prometheus_docker_network_subnet }}"
+    ipam_config:
+      - subnet: "{{ prometheus_docker_network_subnet }}"
     state: present
 
 - name: Pull Docker images.


### PR DESCRIPTION
This adds an automatic garbage collection script to clean out the
registry of old images/tags over time. Uses a helper script to remove
old tags and then invokes registry GC.

Also:

- fixed issue with os_user module not running
- updated docker_network invocations