### PR TITLE
Expose Prometheus UI

### DIFF
--- a/playbooks/prometheus.yml
+++ b/playbooks/prometheus.yml
@@ -19,17 +19,51 @@
   roles:
     - prometheus
   tasks:
-    - name: Set facts for gathering in frontend hosts.
-      set_fact:
-        prometheus_alertmanager_hostname: "{{ prometheus_alertmanager_hostname }}"
+    - set_fact:
         prometheus_alertmanager_port: "{{ prometheus_services['alertmanager'].port }}"
         prometheus_alertmanager_users: "{{ prometheus_alertmanager_users }}"
-      tags:
-        - configuration
       when: inventory_hostname in groups[prometheus_services['alertmanager'].group]
+    - set_fact:
+        prometheus_server_port: "{{ prometheus_services['server'].port }}"
+        prometheus_server_users: "{{ prometheus_server_users }}"
+      when: inventory_hostname in groups[prometheus_services['server'].group]
 
 - hosts: frontends
   tasks:
+    - name: Configure virtual host for Prometheus server.
+      block:
+        - set_fact:
+            prometheus_server: "{{ hostvars[groups['prometheus'][0]] }}"
+        - name: Configure virtual host.
+          include_role:
+            name: apache
+            tasks_from: host
+          vars:
+            apache_server_alias: prometheus_server
+            apache_server_name: "{{ prometheus_server_hostname }}"
+            apache_server_https_port: 9090
+            apache_server_http_port: null
+            apache_server_conf: |
+              <Location "/">
+                Order deny,allow
+                Allow from all
+
+                AuthType Basic
+                AuthName "Prometheus authentication"
+                AuthBasicProvider socache external
+                AuthExternal keystone-user
+                AuthExternalProvideCache On
+                AuthnCacheProvideFor keystone-user
+
+                Require user {{ prometheus_server.prometheus_server_users | join(' ') }}
+
+                # preserve Host header to avoid cross-origin problems
+                ProxyPreserveHost on
+                # proxy to Alertmanager
+                ProxyPass         http://{{ groups['prometheus'][0] }}:{{ prometheus_server.prometheus_server_port }}/
+                ProxyPassReverse  http://{{ groups['prometheus'][0] }}:{{ prometheus_server.prometheus_server_port }}/
+              </Location>
+          when: prometheus_server_hostname is defined
     - name: Configure virtual host for Prometheus Alertmanager.
       block:
         - set_fact:
@@ -39,7 +73,8 @@
             name: apache
             tasks_from: host
           vars:
-            apache_server_name: "{{ prometheus_alertmanager.prometheus_alertmanager_hostname }}"
+            apache_server_alias: prometheus_alertmanager
+            apache_server_name: "{{ prometheus_alertmanager_hostname }}"
             apache_server_conf: |
               <Location "/">
                 Order deny,allow
@@ -57,8 +92,7 @@
                 # preserve Host header to avoid cross-origin problems
                 ProxyPreserveHost on
                 # proxy to Alertmanager
-                ProxyPass         http://{{ groups.prometheus[0] }}:{{ prometheus_alertmanager.prometheus_alertmanager_port }}/
-                ProxyPassReverse  http://{{ groups.prometheus[0] }}:{{ prometheus_alertmanager.prometheus_alertmanager_port }}/
+                ProxyPass         http://{{ groups['prometheus-alertmanager'][0] }}:{{ prometheus_alertmanager.prometheus_alertmanager_port }}/
+                ProxyPassReverse  http://{{ groups['prometheus-alertmanager'][0] }}:{{ prometheus_alertmanager.prometheus_alertmanager_port }}/
               </Location>
-          tags:
-            - configuration
+          when: prometheus_alertmanager_hostname is defined

--- a/roles/apache/tasks/host.yml
+++ b/roles/apache/tasks/host.yml
@@ -19,12 +19,12 @@
     name: "{{ apache_config_path }}/conf.d"
     state: directory
 
-- name: "Create Apache configuration for {{ apache_server_name }}"
+- name: "Create Apache configuration for {{ apache_server_alias | default(apache_server_name) }}"
   template:
     src: vhost.conf.j2
     dest: "{{ apache_config_path }}/conf.d/{{ apache_server_priority }}-{{ apache_server_name_normalized }}.conf"
   vars:
-    apache_server_name_normalized: "{{ apache_server_name | replace('.', '_') }}"
+    apache_server_name_normalized: "{{ apache_server_alias | default(apache_server_name | replace('.', '_')) }}"
   tags:
     - configuration
     - apache

--- a/roles/apache/templates/vhost.conf.j2
+++ b/roles/apache/templates/vhost.conf.j2
@@ -1,10 +1,12 @@
 # {{ ansible_managed }}
 # Virtual host for {{ apache_server_name }}
 
+{% if apache_server_http_port is not none %}
 <VirtualHost {{ external_vip_address }}:{{ apache_server_http_port }}>
   ServerName {{ apache_server_name }}
   Redirect / https://{{ apache_server_name }}/
 </VirtualHost>
+{% endif %}
 
 <VirtualHost {{ external_vip_address }}:{{ apache_server_https_port }}>
   ServerName {{ apache_server_name }}

--- a/roles/prometheus/defaults/main.yml
+++ b/roles/prometheus/defaults/main.yml
@@ -1,12 +1,15 @@
 prometheus_docker_network_name: prometheus
 prometheus_docker_network_subnet: 172.18.0.0/24
 
+# Users allowed to access the web UIs
+prometheus_users: []
+
+prometheus_server_users: "{{ prometheus_users }}"
+
 enable_prometheus_alertmanager: yes
 # This should be encrypted! It is a secret value.
 prometheus_alertmanager_slack_api_url: "{{ slack_api_url }}"
-prometheus_alertmanager_users:
-  - jakecoll
-  - jason_a
+prometheus_alertmanager_users: "{{ prometheus_users }}"
 
 prometheus_mysql_exporter_user: mysqld-exporter
 
@@ -27,6 +30,7 @@ prometheus_services:
       - "--web.console.libraries=/usr/share/prometheus/console_libraries"
       - "--web.console.templates=/usr/share/prometheus/consoles"
       - "--web.enable-lifecycle"
+      - "--web.external-url=https://{{ prometheus_server_hostname }}"
     volumes:
       - "prometheus-data:/prometheus"
       - "/etc/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml"


### PR DESCRIPTION
This allows exposing the Prometheus web interface over port 8080 on some
host. The host is user-definable. Before, this interface was not
exposed, and it was a bit hard to work with.