### PR TITLE
[prometheus] Use built-in Ceph exporters

### DIFF
--- a/roles/prometheus/defaults/main.yml
+++ b/roles/prometheus/defaults/main.yml
@@ -96,6 +96,14 @@ prometheus_services:
     scrape_target: no
     volumes:
      - "/etc/prometheus/snmp-exporter:/etc/snmp_exporter"
+  ceph-exporter:
+    group: prometheus-ceph-exporter
+    port: 9283
+    scrape_target: yes
+  ceph-node-exporter:
+    group: prometheus-ceph-exporter
+    port: 9100
+    scrape_target: yes
   push-gateway:
     service_name: prometheus_pushgateway
     image: prom/pushgateway:v0.8.0

--- a/roles/prometheus/templates/prometheus.yml.j2
+++ b/roles/prometheus/templates/prometheus.yml.j2
@@ -3,7 +3,6 @@
 {% set snmp_exporter_service = prometheus_services['snmp-exporter'] %}
 {% set snmp_exporter_vars = hostvars[groups[snmp_exporter_service.group][0]] %}
 {% set snmp_exporter_switches = switch_configs | selectattr('snmp', 'defined') | list %}
-{% set ceph_mgr_nodes = groups['storage-monitoring'] | map('extract', hostvars, ['ansible_default_ipv4', 'address']) | list %}
 ---
 global:
   scrape_interval:     30s
@@ -57,22 +56,3 @@ scrape_configs:
     - target_label: __address__
       replacement: '{{ snmp_exporter_vars['ansible_' + snmp_exporter_vars['network_interface']]['ipv4']['address'] }}:{{ snmp_exporter_service.port }}'
 {% endfor %}
-{% if ceph_mgr_nodes | length > 0 %}
-- job_name: 'node'
-  static_configs:
-    - targets:
-{% for host in ceph_mgr_nodes %}
-        - "{{ host }}:9283"
-{% endfor %}
-      labels:
-        cluster: "{{ chameleon_site_name }}"
-- job_name: 'ceph'
-  honor_labels: true
-  static_configs:
-    - targets:
-{% for host in ceph_mgr_nodes %}
-        - "{{ host }}:9100"
-{% endfor %}
-      labels:
-        instance: "ceph"
-{% endif %}


### PR DESCRIPTION
Ceph has the ability to enable Ceph exporters natively[1]. This
leverages that functionality as opposed to installing new exporters on
the node ourselves.

It is already possible to define jobs that don't provision/install a
service, but rather assume that a port is already exposing metrics.

- This will remove the 'cluster' label, but it doesn't look like we
really need that.

[1]: https://docs.ceph.com/docs/master/mgr/prometheus/