### PR TITLE
Cleanup cron notifications on backup scripts

### DIFF
--- a/roles/common/defaults/cron.yml
+++ b/roles/common/defaults/cron.yml
@@ -1,0 +1,2 @@
+---
+cron_notification: /usr/local/sbin/notification

--- a/roles/common/tasks/cron.yml
+++ b/roles/common/tasks/cron.yml
@@ -1,0 +1,14 @@
+---
+- name: Add cron success notification script
+  template:
+    src: notification.sh.j2
+    dest: "{{ cron_notification }}"
+    mode: 0700
+  vars:
+    prometheus_push_gateway: "http://{{ groups['prometheus-push-gateway'][0] }}:9091"
+
+# Set a fact so that when these tasks are included, the including
+# role can reference this value.
+- name: Set fact for notification script path
+  set_fact:
+    cron_notification: "{{ cron_notification }}"

--- a/roles/common/templates/notification.sh.j2
+++ b/roles/common/templates/notification.sh.j2
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+curl --data-binary @- {{ prometheus_push_gateway }}/metrics/job/cron <<DATA
+# TYPE cron_last_success gauge
+# HELP cron_last_success The timestamp of the last time this cron job completed successfully.
+cron_last_success{name="$1"} $(date +%s)
+DATA

--- a/roles/glance/defaults/main.yml
+++ b/roles/glance/defaults/main.yml
@@ -1,6 +1,4 @@
 ---
-# defaults file for glance
-
 glance_backup_container_name: glance_backup
 glance_backup_segment_size: 4831838208
 glance_backup_cron_name: glance-backup

--- a/roles/glance/tasks/main.yml
+++ b/roles/glance/tasks/main.yml
@@ -1,23 +1,15 @@
 ---
-#- name: Generate SWIFT auth token for Glance backup
-#  os_auth:
-#   auth: "{{ openstack_auth }}"
-
-#- name: Set fact for SWIFT auth token
-#  set_fact:
-#    glance_backup_auth_token: "{{ ansible_facts.auth_token }}"
-
+- name: Include cron notification script
+  include_role:
+    name: common
+    tasks_from: cron
+    defaults_from: cron
+    
 - name: Configure glance backup script file
   template:
     src: glance.j2
     mode: 0700
     dest: /usr/local/sbin/glance-backup
-
-- name: Configure glance prometheus notification script file
-  template:
-    src: notification.j2
-    mode: 0700
-    dest: "{{ glance_backup_notification }}"
 
 - name: Add glance backup cron jobs.
   cron:
@@ -27,5 +19,4 @@
     day: "{{ glance_backup_cron_day }}"
     month: "{{ glance_backup_cron_month }}"
     weekday: "{{ glance_backup_cron_weekday }}"
-    job: '{{ glance_backup_cron_script }} && {{ glance_backup_notification }} "glance_backup"'
-
+    job: "{{ glance_backup_cron_script }} && {{ cron_notification }} glance_backup"

--- a/roles/glance/templates/notification.j2
+++ b/roles/glance/templates/notification.j2
@@ -1,1 +1,0 @@
-echo "cron_last_success{name=\"$1\"} $(date +%s)" | curl --data-binary @- "{{ prometheus_server_url }}":9091/metrics/job/cron

--- a/roles/gnocchi/defaults/main.yml
+++ b/roles/gnocchi/defaults/main.yml
@@ -1,8 +1,5 @@
 ---
-# defaults file for gnocchi
-
 gnocchi_backup_name: gnocchi_backup
 gnocchi_backup_file_prefix: gnocchi_backup_
 gnocchi_backup_container: gnocchi_backup
 gnocchi_backup_cron_name: gnocchi-backup
-

--- a/roles/gnocchi/tasks/main.yml
+++ b/roles/gnocchi/tasks/main.yml
@@ -1,3 +1,10 @@
+---
+- name: Include cron notification script
+  include_role:
+    name: common
+    tasks_from: cron
+    defaults_from: cron
+    
 - name: Generate SWIFT auth token for Gnocchi backup
   local_action:
     module: os_auth
@@ -13,12 +20,6 @@
     mode: 0700
     dest: /usr/local/sbin/gnocchi-backup
 
-- name: Configure gnocchi prometheus notification script file
-  template:
-    src: notification.j2
-    mode: 0700
-    dest: "{{ gnocchi_backup_notification }}"
-
 - name: Add gnocchi backup cron jobs
   cron:
     name: "{{ gnocchi_backup_cron_name }}"
@@ -27,5 +28,4 @@
     day: "{{ gnocchi_backup_cron_day }}"
     month: "{{ gnocchi_backup_cron_month }}"
     weekday: "{{ gnocchi_backup_cron_weekday }}"
-    job: '{{ gnocchi_backup_cron_script }} && {{ gnocchi_backup_notification }} "gnocchi_backup"'
-
+    job: "{{ gnocchi_backup_cron_script }} && {{ cron_notification }} gnocchi_backup"

--- a/roles/gnocchi/templates/notification.j2
+++ b/roles/gnocchi/templates/notification.j2
@@ -1,1 +1,0 @@
-echo "cron_last_success{name=\"$1\"} $(date +%s)" | curl --data-binary @- "{{ prometheus_server_url }}":9091/metrics/job/cron

--- a/roles/mariadb/defaults/main.yml
+++ b/roles/mariadb/defaults/main.yml
@@ -1,6 +1,4 @@
 ---
-# defaults file for mariadb
-
 mariadb_backup_max_packet: 1M
 mariadb_backup_file_age: 29
 mariadb_backup_cron_name: mariadb-backup

--- a/roles/mariadb/tasks/main.yml
+++ b/roles/mariadb/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: Include cron notification script
+  include_role:
+    name: common
+    tasks_from: cron
+    defaults_from: cron
+
 - name: Configure mariadb backup script file
   template:
     src: mariadb.j2
@@ -13,12 +19,6 @@
     dest: "{{ mariadb_backup_cron_script }}"
   when: inventory_hostname_short == "dev"
 
-- name: Configure mariadb prometheus notification script file
-  template:
-    src: notification.j2
-    mode: 0700
-    dest: "{{ mariadb_backup_notification }}"
-
 - name: Add mariadb backup cron jobs.
   cron:
     name: "{{ mariadb_backup_cron_name }}"
@@ -27,4 +27,4 @@
     day: "{{ mariadb_backup_cron_day }}"
     month: "{{ mariadb_backup_cron_month }}"
     weekday: "{{ mariadb_backup_cron_weekday }}"
-    job: '{{ mariadb_backup_cron_script }} && {{ mariadb_backup_notification }} "mariadb-backup"'
+    job: "{{ mariadb_backup_cron_script }} && {{ cron_notification }} mariadb-backup"

--- a/roles/mariadb/templates/notification.j2
+++ b/roles/mariadb/templates/notification.j2
@@ -1,1 +1,0 @@
-echo "cron_last_success{name=\"$1\"} $(date +%s)" | curl --data-binary @- "{{ prometheus_server_url }}":9091/metrics/job/cron


### PR DESCRIPTION
Instead of defining the same notification script in multiple places, all
of which will override others when they run on the same host, pull that
part out to a common task and include it from the other roles.

Also updates the notification script to include some helpful information
e.g. the type and help text for the metric, which Prometheus needs in
order to make sense of this.