### PR TITLE
Update to make stress test more flexible

### DIFF
--- a/playbooks/stress_ram.yml
+++ b/playbooks/stress_ram.yml
@@ -31,7 +31,6 @@
       --timeout 1440m
       --vm-method all
       --vm 90%
-      --vm-bytes 1G
-
-
-  
+      --vm-bytes "{{ (ansible_memfree_mb*1024) |int|abs }}k"
+      -m 1
+      -vm-keep


### PR DESCRIPTION
Utilizing native ansible fact info to make the test more flexible for different mem sized nodes.