### PR TITLE
[common] Add restart fluentd cron job

### DIFF
--- a/playbooks/cron.yml
+++ b/playbooks/cron.yml
@@ -14,3 +14,10 @@
         job: "/usr/bin/docker restart fluentd | /usr/bin/logger -t {{ job_name }} && {{ cron_notification }} {{ job_name }}"
       vars:
         job_name: restart-fluentd
+
+- hosts: elasticsearch
+  tasks:
+    - name: Add ElasticSearch cron job
+      include_role:
+        name: common
+        tasks_from: elasticsearch

--- a/playbooks/cron.yml
+++ b/playbooks/cron.yml
@@ -1,0 +1,16 @@
+---
+- hosts: baremetal
+  tasks:
+    - name: Add common cron jobs
+      include_role:
+        name: common
+        defaults_from: cron
+        tasks_from: cron
+    - name: Add fluentd restart job
+      cron:
+        name: "{{ job_name }}"
+        minute: 0
+        hour: "*/6"
+        job: "/usr/bin/docker restart fluentd | /usr/bin/logger -t {{ job_name }} && {{ cron_notification }} {{ job_name }}"
+      vars:
+        job_name: restart-fluentd

--- a/roles/common/tasks/elasticsearch.yml
+++ b/roles/common/tasks/elasticsearch.yml
@@ -1,0 +1,14 @@
+---
+- name: Add ElasticSeach clean up script
+  template:
+    src: clean_es_curator.sh.j2
+    dest: /usr/local/sbin/clean_es_curator
+    mode: 0700
+  vars:
+    es_curator_retention_days: 5
+- name: Add ElasticSearch clean up job
+  cron:
+    name: "clean-es-curator"
+    minute: 55
+    hour: 5
+    job: "/usr/local/sbin/clean_es_curator"

--- a/roles/common/templates/clean_es_curator.sh.j2
+++ b/roles/common/templates/clean_es_curator.sh.j2
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+es_host="{{ kolla_internal_vip_address }}:9200"
+retention_days={{ es_curator_retention_days }}
+
+echo "Cleaning up indices with retention of $retention_days"
+
+indices=$(curl -Ss "$es_host/_cat/indices" | grep flog- | awk '{ print $3 }' | sort)
+
+days=$retention_days
+next_index() {
+  days=$1
+  echo flog-$(date +%Y.%m.%d -d "-$days day")
+}
+
+index=$(next_index $days)
+limit=365
+while [[ $days -lt $limit ]]; do
+  if [[ "$indices" == *"$index"* ]]; then
+    echo "Trying to delete $index"
+    curl -XDELETE "$es_host/$index"
+  fi
+  days=$((days+1))
+  index=$(next_index $days)
+done


### PR DESCRIPTION
Centralized logging fails when ElasticSearch can't connect to fluentd. This
solution is a bit hacky, but restarting fluentd every few hours seems to
solve the issue.

Wasn't sure this was the best place to put this...