### PR TITLE
Update cc-ansible to pull KA from checkout tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,9 @@
 .facts/
 # When ansible fails, retry files are left in the playbooks directory
 *.retry
-# Checksums for dependencies
+# Checksums/stamps for dependencies
 *.sha256
+*.gitref
 # The default site-config is generated here
 site-config/
 # The vault passwords are stored here by convention

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "kolla/kolla-ansible"]
-	path = kolla/kolla-ansible
-    url = https://github.com/ChameleonCloud/kolla-ansible.git
-    branch = chameleoncloud/rocky

--- a/cc-ansible
+++ b/cc-ansible
@@ -58,7 +58,7 @@ done
 #
 
 init() {
-  local site_config="${CC_ANSIBLE_SITE:-$DIR/site-config}"
+  local site_config="$CC_ANSIBLE_SITE"
   
   if [[ -d "$site_config" ]]; then
     echo "Site config already exists at $site_config! Aborting."
@@ -156,6 +156,29 @@ get_defined_var() {
     | jq -r ".$varname"
 }
 
+# On init, there is no requirement that the site config directory be defined,
+# because one of init's tasks is creating this directory. Set a default.
+if [[ "${command:-}" == "init" ]]; then
+  CC_ANSIBLE_SITE="${CC_ANSIBLE_SITE:-$DIR/site-config}"
+elif [[ -z "${CC_ANSIBLE_SITE:-}" ]]; then
+  cat <<ERRMSG
+Error: no site specified! Please specify which site to execute under with either
+the --site <dir> flag or by setting the CC_ANSIBLE_SITE environment variable.
+
+Example:
+  cc-ansible --site /etc/sites/production
+
+  CC_ANSIBLE_SITE=/etc/sites/production $(basename $0)
+ERRMSG
+  exit 1
+fi
+
+CC_ANSIBLE_VAULT_PASSWORD="${CC_ANSIBLE_VAULT_PASSWORD:-$CC_ANSIBLE_SITE/vault_password}"
+CC_ANSIBLE_ENV="$CC_ANSIBLE_SITE/.env"
+if [[ -f "$CC_ANSIBLE_ENV" ]]; then
+  set -a; source "$CC_ANSIBLE_ENV"; set +a
+fi
+
 # Automatically update dependencies
 if [[ "$CHECK_UPDATES" == "yes" || "$FORCE_UPDATES" == "yes" ]]; then
   # Update base pip packages
@@ -177,19 +200,16 @@ if [[ "$CHECK_UPDATES" == "yes" || "$FORCE_UPDATES" == "yes" ]]; then
     sha256sum "$galaxy_role_requirements" > "$galaxy_role_requirements_chksum"
   fi
 
-  # Update vendored Kolla-Ansible
-  kolla_ansible_submodule_status="$(git submodule status kolla/kolla-ansible)"
-  case "${kolla_ansible_submodule_status:0:1}" in
-    -|+)
-      git submodule update --init kolla/kolla-ansible
-      (cd kolla/kolla-ansible; python setup.py install; pip install -r requirements.txt)
-      ;;
-    *)
-      ;;
-  esac
-  # Handle case of venv being recreated though submodule is up to date.
-  if ! pip freeze | grep -q kolla-ansible; then
-    (cd kolla/kolla-ansible; python setup.py install; pip install -r requirements.txt)
+  kolla_ansible_remote=https://github.com/chameleoncloud/kolla-ansible.git
+  kolla_ansible_checkout=${KOLLA_ANSIBLE_BRANCH:-chameleoncloud/train}
+  kolla_ansible_gitref="$DIR/kolla-ansible.gitref"
+  kolla_ansible_egglink="$DIR/venv/src/kolla-ansible"
+  if [[ "$FORCE_UPDATES" == "yes" || ! -f "$kolla_ansible_gitref" || ! -d "$kolla_ansible_egglink" ]] || \
+        ! diff -q >/dev/null \
+          $kolla_ansible_gitref \
+          <(cd $kolla_ansible_egglink; git fetch; git show-ref -s -d origin/$kolla_ansible_checkout); then
+    pip install -e git+$kolla_ansible_remote@$kolla_ansible_checkout#egg=kolla-ansible
+    (cd $kolla_ansible_egglink; git rev-parse HEAD > $kolla_ansible_gitref)
   fi
 
   # Update Mitogen
@@ -203,28 +223,6 @@ if [[ "$CHECK_UPDATES" == "yes" || "$FORCE_UPDATES" == "yes" ]]; then
   fi
   ln -sf "$MITOGEN_INSTALL_DIR" "$DIR/venv/lib/mitogen-latest"
 fi
-
-# Check for 'init' command first, as it should work even if the 'site' vars
-# are defined.
-if [[ "${command:-}" == "init" ]]; then
-  init
-  exit $?
-fi
-
-if [[ -z "${CC_ANSIBLE_SITE:-}" ]]; then
-  cat <<ERRMSG
-Error: no site specified! Please specify which site to execute under with either
-the --site <dir> flag or by setting the CC_ANSIBLE_SITE environment variable.
-
-Example:
-  cc-ansible --site /etc/sites/production
-
-  CC_ANSIBLE_SITE=/etc/sites/production $(basename $0)
-ERRMSG
-  exit 1
-fi
-
-CC_ANSIBLE_VAULT_PASSWORD="${CC_ANSIBLE_VAULT_PASSWORD:-$CC_ANSIBLE_SITE/vault_password}"
 
 # Handle subcommands
 if [[ -n $command ]]; then


### PR DESCRIPTION
Instead of using a Git submodule, the script will now attempt to install
the package via pip using a GitHub link. To avoid doing extra work, we
try to check the refs and only re-install if the refs no longer match.

This allows you to specify different versions of Kolla-Ansible at
runtime, which allows this repo to serve multiple openstack releases
simultaneously (for example.)

This is aided by support for a new file .env in a site config, which can
specify arbitrary env variables.