### PR TITLE
[prometheus] Better Slack alerts

### DIFF
--- a/roles/prometheus/files/slack.tmpl
+++ b/roles/prometheus/files/slack.tmpl
@@ -1,16 +1,33 @@
-{{ define "slack.chameleon.text" }}
-{{ .CommonAnnotations.description }}
-{{ if .CommonAnnotations.runbook -}}
-<{{ .CommonAnnotations.runbook }}|:notebook: Runbook>
-{{- else -}}
-*No Runbook!* <https://github.com/ChameleonCloud/ansible-playbooks/wiki|Add runbook>
-{{- end }}
-{{ end }}
-
 {{ define "slack.chameleon.color" }}
 {{- if eq .Status "firing" -}}
   {{ if eq .CommonLabels.severity "warning" }}warning{{ else }}danger{{ end }}
 {{- else -}}
   good
 {{- end -}}
+{{ end }}
+
+{{ define "slack.chameleon.title" }}
+[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }} @ {{ .CommonLabels.hostname }} ({{ .CommonAnnotations.severity }})
+{{ end }}
+
+{{ define "slack.chameleon.text" }}
+{{ if or (and (eq (len .Alerts.Firing) 1) (eq (len .Alerts.Resolved) 0)) (and (eq (len .Alerts.Firing) 0) (eq (len .Alerts.Resolved) 1)) }}
+{{ range .Alerts.Firing }}{{ .Annotations.description }}{{ end }}{{ range .Alerts.Resolved }}{{ .Annotations.description }}{{ end }}
+{{ else }}
+{{- if gt (len .Alerts.Firing) 0 }}
+*Alerts Firing:*
+{{ range .Alerts.Firing }}- {{ .Annotations.description }}
+{{ end }}{{ end }}
+{{- if gt (len .Alerts.Resolved) 0 }}
+*Alerts Resolved:*
+{{ range .Alerts.Resolved }}- {{ .Annotations.description }}
+{{ end }}{{ end }}
+{{ end }}
+{{- if gt (len .Alerts.Firing) 0 -}}
+  {{ if .CommonAnnotations.runbook -}}
+    <{{ .CommonAnnotations.runbook }}|:notebook: Runbook>
+  {{- else -}}
+    *No Runbook!* <https://github.com/ChameleonCloud/ansible-playbooks/wiki|Add runbook>
+  {{- end }}
+{{- end }}
 {{ end }}

--- a/roles/prometheus/templates/alertmanager.yml.j2
+++ b/roles/prometheus/templates/alertmanager.yml.j2
@@ -32,6 +32,8 @@ receivers:
   slack_configs:
   - channel: '#notifications'
     send_resolved: true
+    title: {% raw %}'{{ template "slack.chameleon.title" . }}'
+{% endraw %}
     text: {% raw %}'{{ template "slack.chameleon.text" . }}'
 {% endraw %}
     color: {% raw %}'{{ template "slack.chameleon.color" . }}'
@@ -45,6 +47,8 @@ receivers:
   slack_configs:
   - channel: '#notifications'
     send_resolved: false
+    title: {% raw %}'{{ template "slack.chameleon.title" . }}'
+{% endraw %}
     text: {% raw %}'{{ template "slack.chameleon.text" . }}'
 {% endraw %}
     color: {% raw %}'{{ template "slack.chameleon.color" . }}'


### PR DESCRIPTION
This updates the default Slack alert formatting to be better at
displaying per-alert descriptions. Uses an approach outlined here[1].

[1]: https://harthoover.com/pretty-alertmanager-alerts-in-slack/