### PR TITLE
Default to Train release

### DIFF
--- a/cc-ansible
+++ b/cc-ansible
@@ -204,7 +204,7 @@ if [[ "$CHECK_UPDATES" == "yes" || "$FORCE_UPDATES" == "yes" ]]; then
   fi
 
   kolla_ansible_remote=https://github.com/chameleoncloud/kolla-ansible.git
-  kolla_ansible_checkout=${KOLLA_ANSIBLE_BRANCH:-chameleoncloud/rocky}
+  kolla_ansible_checkout=${KOLLA_ANSIBLE_BRANCH:-chameleoncloud/train}
   kolla_ansible_gitref="$VIRTUALENV/kolla-ansible.gitref"
   kolla_ansible_egglink="$VIRTUALENV/src/kolla-ansible"
   if [[ "$FORCE_UPDATES" == "yes" || ! -f "$kolla_ansible_gitref" || ! -d "$kolla_ansible_egglink" ]] || \

--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -1,7 +1,6 @@
 ---
-openstack_release: rocky
-blazar_tag: stein
-cloud: "envvars"
+openstack_release: train 
+cloud: envvars
 
 docker_namespace: kolla
 docker_registry_username: registry

--- a/kolla/node_custom_config/nova.conf
+++ b/kolla/node_custom_config/nova.conf
@@ -6,7 +6,7 @@ vif_plugging_timeout = 0
 max_concurrent_builds = 0
 
 [compute]
-# https://docs.openstack.org/ironic/rocky/install/configure-compute.html
+# https://docs.openstack.org/ironic/train/install/configure-compute.html
 # > This option will cause nova-compute to set itself to a disabled state
 #   if a certain number of consecutive build failures occur. This will
 #   prevent the scheduler from continuing to send builds to a compute
@@ -25,11 +25,11 @@ workers = 10
 # Override default filters (just remove filters not relevant to baremetal-only)
 # default: AvailabilityZoneFilter,ComputeFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter,BlazarFilter
 enabled_filters = ComputeFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,BlazarFilter
-# https://docs.openstack.org/ironic/rocky/install/configure-compute.html
+# https://docs.openstack.org/ironic/train/install/configure-compute.html
 # > Enables querying of individual hosts for instance information.
 #   Not possible for bare metal nodes, so set it to False.
 track_instance_changes = false
-# https://docs.openstack.org/ironic/rocky/install/configure-compute.html
+# https://docs.openstack.org/ironic/train/install/configure-compute.html
 # > Enabling this option is beneficial as it reduces re-scheduling events
 #   for ironic nodes when scheduling is based on resource classes,
 #   especially for mixed hypervisor case with host_subset_size = 1.
@@ -58,7 +58,7 @@ reservation_expire = 86400
 instances = -1
 cores = -1
 ram = -1
-# https://docs.openstack.org/nova/rocky/configuration/config.html#quota.recheck_quota
+# https://docs.openstack.org/nova/train/configuration/config.html#quota.recheck_quota
 # > This defaults to True (recheck quota after resource creation) but can be set
 #   to False to avoid additional load if allowing quota to be exceeded because
 #   of racing requests is considered acceptable.
@@ -70,7 +70,7 @@ recheck_quota = false
 # This seems quite high. We potentially don't need to keep it this high.
 # This is the value we have used in the past however.
 max_attempts = 50
-# https://docs.openstack.org/ironic/rocky/install/configure-compute.html
+# https://docs.openstack.org/ironic/train/install/configure-compute.html
 # > The recommended value of 2 minutes matches how often the Compute
 #   service polls the Bare Metal service for node information.
 discover_hosts_in_cells_interval = 120


### PR DESCRIPTION
All of our clouds are now on Train, so it makes sense to default, lest we accidentally revert to Rocky in the future.