### PR TITLE
[keycloak] Use HAProxy for setting up HTTP services

### DIFF
--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -1,5 +1,5 @@
 ---
-openstack_release: train 
+openstack_release: train
 cloud: envvars
 
 docker_namespace: kolla
@@ -90,6 +90,10 @@ ironic_pxe_append_params: "nofb nomodeset vga=normal console=tty0 console=ttyS0,
 #      - {'interface': 'admin', 'url': '{{ ironic_admin_endpoint }}'}
 #      - {'interface': 'internal', 'url': '{{ ironic_internal_endpoint }}'}
 #      - {'interface': 'public', 'url': '{{ ironic_public_endpoint }}'}
+
+# Keycloak
+enable_keycloak: no
+enable_keycloak_external: "{{ enable_keycloak }}"
 
 # Keystone
 enable_keystone: yes

--- a/playbooks/action_plugins/chi_docker_service.py
+++ b/playbooks/action_plugins/chi_docker_service.py
@@ -114,7 +114,7 @@ class ActionModule(action.ActionBase):
         mounts = module_args.get("mounts", [])
         ports = module_args.get("ports", [])
         environment = module_args.get("environment", {})
-        bind_address = module_args.get("bind_address", None)
+        bind_address = module_args.get("bind_address", task_vars.get("api_interface_address"))
         stop_timeout = module_args.get("stop_timeout", DEFAULT_STOP_TIMEOUT)
 
         try:

--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -1,22 +1,66 @@
 ---
-keycloak_config_path: /etc/keycloak
-keycloak_docker_image: docker.chameleoncloud.org/keycloak:7
-keycloak_docker_network: keycloak
-keycloak_docker_network_subnet: 172.18.1.0/28
-keycloak_docker_volume_name: keycloak-storage
+project_name: keycloak
+
 keycloak_hostname: auth.chameleoncloud.org
 keycloak_port: 8085  # Just needs to be something that doesn't conflict
-keycloak_service_name: keycloak
-keycloak_backup_docker_volume_name: keycloak-backup
 
 # The admin user provisioned by default in Keycloak
 keycloak_user: admin
 # keycloack_password
 
-keycloak_db_service_name: keycloak-db
-keycloak_db_docker_image: mariadb:10.3
-keycloak_db_docker_volume_name: keycloak-db-storage
+keycloak_docker_network: keycloak
+keycloak_docker_network_subnet: 172.18.1.0/28
+
 keycloak_db_user: keycloak
 keycloak_db_db: keycloak
 # keycloak_db_root_password
 # keycloak_db_password
+
+keycloak_services:
+  keycloak_server:
+    group: keycloak_server
+    enabled: true
+    image: docker.chameleoncloud.org/keycloak:7
+    network: "{{ keycloak_docker_network }}"
+    environment:
+      DB_VENDOR: mariadb
+      DB_ADDR: keycloak_db
+      DB_DATABASE: "{{ keycloak_db_db }}"
+      DB_USER: "{{ keycloak_db_user }}"
+      DB_PASSWORD: "{{ keycloak_db_password }}"
+      KEYCLOAK_USER: "{{ keycloak_user }}"
+      KEYCLOAK_PASSWORD: "{{ keycloak_password }}"
+      JGROUPS_DISCOVERY_PROTOCOL: JDBC_PING
+      JGROUPS_DISCOVERY_PROPERTIES: datasource_jndi_name=java:jboss/datasources/KeycloakDS,info_writer_sleep_time=500
+    ports:
+      - "{{ keycloak_port }}:8080"
+    mounts:
+      - type: volume
+        src: keycloak_backup
+        dst: /backup
+    haproxy:
+      keycloak_server:
+        enabled: "{{ enable_keycloak }}"
+        mode: "http"
+        port: "{{ keycloak_port }}"
+        listen_port: "{{ keycloak_port }}"
+      keycloak_server_external:
+        enabled: "{{ enable_keycloak_external }}"
+        mode: "http"
+        external: true
+        port: "{{ keycloak_port }}"
+        listen_port: "{{ keycloak_port }}"
+  keycloak_db:
+    group: keycloak_db
+    enabled: true
+    image: mariadb:10.3
+    network: "{{ keycloak_docker_network }}"
+    environment:
+      MYSQL_ROOT_PASSWORD: "{{ keycloak_db_root_password }}"
+      MYSQL_USER: "{{ keycloak_db_user }}"
+      MYSQL_PASSWORD: "{{ keycloak_db_password }}"
+      MYSQL_DATABASE: "{{ keycloak_db_db }}"
+    mounts:
+      - type: volume
+        src: keycloak_db_storage
+        dst: /var/lib/mysql

--- a/roles/keycloak/tasks/main.yml
+++ b/roles/keycloak/tasks/main.yml
@@ -2,11 +2,11 @@
 - name: Pull Keycloak images.
   docker_image:
     source: pull
-    name: "{{ item }}"
+    name: "{{ item.value.image }}"
     force_source: yes
-  loop:
-    - "{{ keycloak_docker_image }}"
-    - "{{ keycloak_db_docker_image }}"
+  loop: "{{ keycloak_services|dict2items }}"
+  loop_control:
+    label: "{{ item.value.image }}"
   tags:
     - pull
 
@@ -16,39 +16,21 @@
     ipam_config:
       - subnet: "{{ keycloak_docker_network_subnet }}"
 
-- name: Configure Keycloack DB.
+- name: Configure Keycloak services.
   chi_docker_service:
-    name: "{{ keycloak_db_service_name }}"
-    image: "{{ keycloak_db_docker_image }}"
-    network: "{{ keycloak_docker_network }}"
-    environment:
-      MYSQL_ROOT_PASSWORD: "{{ keycloak_db_root_password }}"
-      MYSQL_USER: "{{ keycloak_db_user }}"
-      MYSQL_PASSWORD: "{{ keycloak_db_password }}"
-      MYSQL_DATABASE: "{{ keycloak_db_db }}"
-    mounts:
-      - type: volume
-        src: "{{ keycloak_db_docker_volume_name }}"
-        dst: /var/lib/mysql
+    name: "{{ item.key }}"
+    image: "{{ item.value.image }}"
+    network: "{{ item.value.network }}"
+    environment: "{{ item.value.environment }}"
+    mounts: "{{ item.value.mounts }}"
+    ports: "{{ item.value.ports|default([]) }}"
+  loop: "{{ keycloak_services|dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
 
-- name: Configure Keycloak service.
-  chi_docker_service:
-    name: "{{ keycloak_service_name }}"
-    image: "{{ keycloak_docker_image }}"
-    network: "{{ keycloak_docker_network }}"
-    environment:
-      DB_VENDOR: mariadb
-      DB_ADDR: "{{ keycloak_db_service_name }}"
-      DB_DATABASE: "{{ keycloak_db_db }}"
-      DB_USER: "{{ keycloak_db_user }}"
-      DB_PASSWORD: "{{ keycloak_db_password }}"
-      KEYCLOAK_USER: "{{ keycloak_user }}"
-      KEYCLOAK_PASSWORD: "{{ keycloak_password }}"
-      JGROUPS_DISCOVERY_PROTOCOL: JDBC_PING
-      JGROUPS_DISCOVERY_PROPERTIES: datasource_jndi_name=java:jboss/datasources/KeycloakDS,info_writer_sleep_time=500
-    ports:
-      - "{{ keycloak_port }}:8080"
-    mounts:
-      - type: volume
-        src: "{{ keycloak_backup_docker_volume_name }}"
-        dst: /backup
+- name: Configure haproxy for Keycloak
+  import_role:
+    name: haproxy-config
+  vars:
+    project_services: "{{ keycloak_services }}"
+  when: enable_haproxy | bool

--- a/site-config.example/inventory/hosts
+++ b/site-config.example/inventory/hosts
@@ -719,3 +719,13 @@ control
 # Chameleon vendordata service
 [vendordata:children]
 control
+
+# Keycloak identity provider
+[keycloak:children]
+control
+
+[keycloak_server:children]
+keycloak
+
+[keycloak_db:children]
+keycloak


### PR DESCRIPTION
This updates the keycloak role to re-use the existing KA HAproxy configuration. This ended up being pretty easy... once support for pulling in KA roles from CHI-in-a-Box was added. It also simplifies the tasks a lot and pushes most stuff to the service configurations in the default vars for the role, which is nice.