### PR TITLE
Disable Keycloak HAProxy frontend

### DIFF
--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -94,6 +94,7 @@ ironic_pxe_append_params: "nofb nomodeset vga=normal console=tty0 console=ttyS0,
 # Keycloak
 enable_keycloak: no
 enable_keycloak_external: "{{ enable_keycloak }}"
+enable_keycloak_external_frontend: no
 
 # Keystone
 enable_keystone: yes

--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -46,6 +46,7 @@ keycloak_services:
         listen_port: "{{ keycloak_port }}"
       keycloak_server_external:
         enabled: "{{ enable_keycloak_external }}"
+        frontend_enabled: "{{ enable_keycloak_external_frontend }}"
         mode: "http"
         external: true
         port: "{{ keycloak_port }}"


### PR DESCRIPTION
This will allow us to route traffic to keycloak via Horizon's frontend (which runs on 443).