### PR TITLE
Add support for Keystone federation

### DIFF
--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -81,6 +81,9 @@ horizon_regions:
 # Keystone IdP federation
 identity_provider_url: "https://{{ keycloak_hostname }}/auth/realms/{{ keycloak_realm_name }}"
 keystone_identity_providers:
+  - name: portal
+    protocol:
+    public_name: Login with TAS (legacy accounts)
   - name: chameleon
     protocol: openid
     identifier: "{{ identity_provider_url }}"

--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -81,9 +81,6 @@ horizon_regions:
 # Keystone IdP federation
 identity_provider_url: "https://{{ keycloak_hostname }}/auth/realms/{{ keycloak_realm_name }}"
 keystone_identity_providers:
-  - name: portal
-    protocol:
-    public_name: Login with TAS (legacy accounts)
   - name: chameleon
     protocol: openid
     identifier: "{{ identity_provider_url }}"

--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -78,6 +78,20 @@ horizon_regions:
     blazar_database_user: "{{ blazar_database_user }}"
     blazar_database_password: "{{ blazar_database_password }}"
 
+# Keystone IdP federation
+identity_provider_url: "https://{{ keycloak_hostname }}/auth/realms/{{ keycloak_realm_name }}"
+keystone_identity_providers:
+  - name: chameleon
+    protocol: openid
+    identifier: "{{ identity_provider_url }}"
+    public_name: Login with Chameleon
+    client_id: "{{ keystone_idp_client_id }}"
+    client_secret: "{{ keystone_idp_client_secret }}"
+    attribute_mapping: chameleon_mapping
+keystone_identity_mappings:
+  - name: chameleon_mapping
+    file: "{{ node_custom_config }}/keystone/idp_mapping.json"
+
 # Ironic
 enable_ironic: yes
 ironic_provisioning_network: ironic-provisioning
@@ -99,6 +113,8 @@ ironic_pxe_append_params: "nofb nomodeset vga=normal console=tty0 console=ttyS0,
 enable_keycloak: no
 enable_keycloak_external: "{{ enable_keycloak }}"
 enable_keycloak_external_frontend: no
+keycloak_realm_name: chameleon
+keycloak_hostname: auth.chameleoncloud.org
 
 # Keystone
 enable_keystone: yes

--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -94,6 +94,7 @@ keystone_identity_providers:
 keystone_identity_mappings:
   - name: chameleon_mapping
     file: "{{ node_custom_config }}/keystone/idp_mapping.json"
+keystone_federation_openid_discovery_url: "{{ chameleon_portal_url }}/auth/oidc_discovery"
 
 # Ironic
 enable_ironic: yes

--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -66,6 +66,9 @@ enable_heat: yes
 # Horizon
 enable_horizon: yes
 enable_horizon_chameleon_websso: yes
+# Keep this to 'no' until we have switched from old multi-region to new
+# multi-keystone model (with federation).
+horizon_use_keystone_internal_url: no
 horizon_help_url: https://chameleoncloud.readthedocs.io/en/latest/technical/baremetal.html
 horizon_redirect_root: /dashboard
 horizon_chameleon_websso_host: https://www.chameleoncloud.org

--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -94,7 +94,6 @@ keystone_identity_providers:
 keystone_identity_mappings:
   - name: chameleon_mapping
     file: "{{ node_custom_config }}/keystone/idp_mapping.json"
-keystone_federation_openid_discovery_url: "{{ chameleon_portal_url }}/auth/oidc_discovery"
 
 # Ironic
 enable_ironic: yes

--- a/kolla/node_custom_config/horizon/custom_local_settings
+++ b/kolla/node_custom_config/horizon/custom_local_settings
@@ -61,26 +61,22 @@ CHAMELEON_SITES = {
 {% endfor %}
 }
 
-{% if enable_keystone_federation | bool %}
+{% if (enable_keystone_federation | bool) or (enable_horizon_chameleon_websso | bool) %}
 WEBSSO_ENABLED = True
 WEBSSO_CHOICES = (
     ('chameleon_portal', _('Chameleon Portal (Legacy)')),
     ('chameleon_openid', _('Chameleon OpenID')),
 )
 WEBSSO_IDP_MAPPING = {
+    'chameleon_portal': (None, None),
     'chameleon_openid': ('chameleon', 'openid'),
 }
 WEBSSO_INITIAL_CHOICE = 'chameleon_portal'
-{% endif %}
-
 {% if enable_horizon_chameleon_websso | bool %}
-# Single-sign on support
-WEBSSO_ENABLED = True
-AUTHENTICATION_URLS = ['openstack_dashboard.cc_web_sso_urls', 'openstack_auth.urls',]
-CHAMELEON_PORTAL_SSO_BASE_URL = '{{ horizon_chameleon_websso_host }}'
-CHAMELEON_PORTAL_SSO_LOGIN_PATH = '/sso/horizon/'
-CHAMELEON_PORTAL_SSO_LOGOUT_PATH = '/logout/'
-SSO_CALLBACK_HOST = '{{ kolla_external_fqdn }}'
+WEBSSO_DEFAULT_REDIRECT = True
+WEBSSO_DEFAULT_REDIRECT_URL = '{{ horizon_chameleon_websso_host }}/sso/horizon'
+WEBSSO_DEFAULT_REDIRECT_LOGOUT = '{{ horizon_chameleon_websso_host }}/logout'
+{% endif %}
 {% endif %}
 
 # A dictionary of settings which can be used to provide the default values for

--- a/kolla/node_custom_config/horizon/custom_local_settings
+++ b/kolla/node_custom_config/horizon/custom_local_settings
@@ -75,7 +75,7 @@ WEBSSO_CHOICES = (
 {% endfor %}
 )
 WEBSSO_IDP_MAPPING = {
-    "portal": (None, None)
+    "portal": (None, None),
 {% for idp in keystone_identity_providers %}
     "{{ idp.name }}": ("{{ idp.name }}", "{{ idp.protocol }}"),
 {% endfor %}

--- a/kolla/node_custom_config/horizon/custom_local_settings
+++ b/kolla/node_custom_config/horizon/custom_local_settings
@@ -61,10 +61,22 @@ CHAMELEON_SITES = {
 {% endfor %}
 }
 
+{% if enable_keystone_federation | bool %}
+WEBSSO_ENABLED = True
+WEBSSO_CHOICES = (
+    ('chameleon_portal', _('Chameleon Portal (Legacy)')),
+    ('chameleon_openid', _('Chameleon OpenID')),
+)
+WEBSSO_IDP_MAPPING = {
+    'chameleon_openid': ('chameleon', 'openid'),
+}
+WEBSSO_INITIAL_CHOICE = 'chameleon_portal'
+{% endif %}
+
 {% if enable_horizon_chameleon_websso | bool %}
 # Single-sign on support
 WEBSSO_ENABLED = True
-AUTHENTICATION_URLS = ['openstack_dashboard.cc_web_sso_urls','openstack_auth.urls',]
+AUTHENTICATION_URLS = ['openstack_dashboard.cc_web_sso_urls', 'openstack_auth.urls',]
 CHAMELEON_PORTAL_SSO_BASE_URL = '{{ horizon_chameleon_websso_host }}'
 CHAMELEON_PORTAL_SSO_LOGIN_PATH = '/sso/horizon/'
 CHAMELEON_PORTAL_SSO_LOGOUT_PATH = '/logout/'

--- a/kolla/node_custom_config/horizon/custom_local_settings
+++ b/kolla/node_custom_config/horizon/custom_local_settings
@@ -1,4 +1,4 @@
-from openstack_dashboard import settings
+from openstack_dashboard.settings import HORIZON_CONFIG
 from os import environ
 
 # Kolla-ansible defaults this to 'internalURL', which doesn't work when
@@ -16,7 +16,7 @@ DEFAULT_SERVICE_REGIONS = {
 SITE_BRANDING = 'ChameleonCloud'
 
 # Override help menu to point to our docs.
-settings.HORIZON_CONFIG['help_url'] = '{{ horizon_help_url }}'
+HORIZON_CONFIG['help_url'] = '{{ horizon_help_url }}'
 
 {% if enable_blazar | bool %}
 # Blazar-specific settings
@@ -62,8 +62,6 @@ CHAMELEON_SITES = {
 }
 
 {% if enable_horizon_chameleon_websso | bool %}
-WEBSSO_CHOICES = settings.WEBSSO_CHOICES + (('portal', 'Chameleon Portal (Legacy)'))
-settings.WEBSSO_IDP_MAPPING['portal'] = (None, None)
 WEBSSO_INITIAL_CHOICE = 'portal'
 WEBSSO_DEFAULT_REDIRECT = True
 WEBSSO_DEFAULT_REDIRECT_URL = '{{ horizon_chameleon_websso_host }}/sso/horizon'

--- a/kolla/node_custom_config/horizon/custom_local_settings
+++ b/kolla/node_custom_config/horizon/custom_local_settings
@@ -1,4 +1,4 @@
-from openstack_dashboard.settings import HORIZON_CONFIG
+from openstack_dashboard import settings
 from os import environ
 
 # Kolla-ansible defaults this to 'internalURL', which doesn't work when
@@ -16,7 +16,7 @@ DEFAULT_SERVICE_REGIONS = {
 SITE_BRANDING = 'ChameleonCloud'
 
 # Override help menu to point to our docs.
-HORIZON_CONFIG['help_url'] = '{{ horizon_help_url }}'
+settings.HORIZON_CONFIG['help_url'] = '{{ horizon_help_url }}'
 
 {% if enable_blazar | bool %}
 # Blazar-specific settings
@@ -61,22 +61,13 @@ CHAMELEON_SITES = {
 {% endfor %}
 }
 
-{% if (enable_keystone_federation | bool) or (enable_horizon_chameleon_websso | bool) %}
-WEBSSO_ENABLED = True
-WEBSSO_CHOICES = (
-    ('chameleon_portal', _('Chameleon Portal (Legacy)')),
-    ('chameleon_openid', _('Chameleon OpenID')),
-)
-WEBSSO_IDP_MAPPING = {
-    'chameleon_portal': (None, None),
-    'chameleon_openid': ('chameleon', 'openid'),
-}
-WEBSSO_INITIAL_CHOICE = 'chameleon_portal'
 {% if enable_horizon_chameleon_websso | bool %}
+WEBSSO_CHOICES = settings.WEBSSO_CHOICES + (('portal', 'Chameleon Portal (Legacy)'))
+settings.WEBSSO_IDP_MAPPING['portal'] = (None, None)
+WEBSSO_INITIAL_CHOICE = 'portal'
 WEBSSO_DEFAULT_REDIRECT = True
 WEBSSO_DEFAULT_REDIRECT_URL = '{{ horizon_chameleon_websso_host }}/sso/horizon'
 WEBSSO_DEFAULT_REDIRECT_LOGOUT = '{{ horizon_chameleon_websso_host }}/logout'
-{% endif %}
 {% endif %}
 
 # A dictionary of settings which can be used to provide the default values for

--- a/kolla/node_custom_config/horizon/custom_local_settings
+++ b/kolla/node_custom_config/horizon/custom_local_settings
@@ -61,12 +61,33 @@ CHAMELEON_SITES = {
 {% endfor %}
 }
 
+# NOTE(jason): This is lifted from local_settings.j2 in Kolla-Ansible; we have
+# to override it to add in a kludgy entry for Portal SSO, which isn't a "true"
+# SSO in the same way as the others, which have e.g. Keystone mappings and
+# assume an identity provider is registered in Keystone. We also remove the
+# local login.
+{% if enable_keystone_federation | bool %}
+WEBSSO_ENABLED = True
+WEBSSO_CHOICES = (
+    ("portal", "Log in with TACC account (Legacy)"),
+{% for idp in keystone_identity_providers %}
+    ("{{ idp.name }}", "{{ idp.public_name }}"),
+{% endfor %}
+)
+WEBSSO_IDP_MAPPING = {
+    "portal": (None, None)
+{% for idp in keystone_identity_providers %}
+    "{{ idp.name }}": ("{{ idp.name }}", "{{ idp.protocol }}"),
+{% endfor %}
+}
+
 {% if enable_horizon_chameleon_websso | bool %}
 AUTHENTICATION_URLS = ['openstack_dashboard.cc_web_sso_urls', 'openstack_auth.urls']
 WEBSSO_INITIAL_CHOICE = 'portal'
 WEBSSO_DEFAULT_REDIRECT = True
 WEBSSO_DEFAULT_REDIRECT_URL = '{{ horizon_chameleon_websso_host }}/sso/horizon'
 WEBSSO_DEFAULT_REDIRECT_LOGOUT = '{{ horizon_chameleon_websso_host }}/logout'
+{% endif %}
 {% endif %}
 
 # A dictionary of settings which can be used to provide the default values for

--- a/kolla/node_custom_config/horizon/custom_local_settings
+++ b/kolla/node_custom_config/horizon/custom_local_settings
@@ -62,6 +62,7 @@ CHAMELEON_SITES = {
 }
 
 {% if enable_horizon_chameleon_websso | bool %}
+AUTHENTICATION_URLS = ['openstack_dashboard.cc_web_sso_urls', 'openstack_auth.urls']
 WEBSSO_INITIAL_CHOICE = 'portal'
 WEBSSO_DEFAULT_REDIRECT = True
 WEBSSO_DEFAULT_REDIRECT_URL = '{{ horizon_chameleon_websso_host }}/sso/horizon'

--- a/kolla/node_custom_config/horizon/custom_local_settings
+++ b/kolla/node_custom_config/horizon/custom_local_settings
@@ -88,6 +88,8 @@ WEBSSO_INITIAL_CHOICE = 'portal'
 WEBSSO_DEFAULT_REDIRECT = True
 WEBSSO_DEFAULT_REDIRECT_URL = '{{ horizon_chameleon_websso_host }}/sso/horizon'
 WEBSSO_DEFAULT_REDIRECT_LOGOUT = '{{ horizon_chameleon_websso_host }}/logout'
+# Show users interstitial page upon logout instead of logging them out of Portal immediately
+WEBSSO_DEFAULT_REDIRECT_LOGOUT_CONFIRM = True
 {% endif %}
 {% endif %}
 

--- a/kolla/node_custom_config/horizon/custom_local_settings
+++ b/kolla/node_custom_config/horizon/custom_local_settings
@@ -68,7 +68,7 @@ CHAMELEON_SITES = {
 # local login.
 {% if enable_keystone_federation | bool %}
 WEBSSO_ENABLED = True
-WEBSSO_KEYSTONE_URL = "{{ keystone_public_url }}"
+WEBSSO_KEYSTONE_URL = "{{ keystone_public_url }}/v3"
 WEBSSO_CHOICES = (
     ("portal", "Log in with TACC account (Legacy)"),
 {% for idp in keystone_identity_providers %}

--- a/kolla/node_custom_config/horizon/custom_local_settings
+++ b/kolla/node_custom_config/horizon/custom_local_settings
@@ -68,6 +68,7 @@ CHAMELEON_SITES = {
 # local login.
 {% if enable_keystone_federation | bool %}
 WEBSSO_ENABLED = True
+WEBSSO_KEYSTONE_URL = "{{ keystone_public_url }}"
 WEBSSO_CHOICES = (
     ("portal", "Log in with TACC account (Legacy)"),
 {% for idp in keystone_identity_providers %}

--- a/kolla/node_custom_config/keystone/idp_mapping.json
+++ b/kolla/node_custom_config/keystone/idp_mapping.json
@@ -1,0 +1,35 @@
+[
+  {
+    "local": [
+      {
+        "user": {
+          "name": "{0}",
+          "email": "{1}"
+        }
+      },
+      {
+        "projects": [
+          {
+            "name": "{2}",
+            "roles": [
+              {
+                "name": "member"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "remote": [
+      {
+        "type": "OIDC-preferred_username"
+      },
+      {
+        "type": "OIDC-email"
+      },
+      {
+        "type": "OIDC-groups"
+      }
+    ]
+  }
+]

--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -2,8 +2,8 @@
 project_name: keycloak
 
 keycloak_hostname: auth.chameleoncloud.org
-keycloak_port: 8085  # Just needs to be something that doesn't conflict
 keycloak_realm_name: chameleon
+keycloak_port: 8085  # Just needs to be something that doesn't conflict
 
 # The admin user provisioned by default in Keycloak
 keycloak_user: admin

--- a/roles/keycloak/tasks/import_realm.yml
+++ b/roles/keycloak/tasks/import_realm.yml
@@ -1,6 +1,0 @@
----
-- name: Import realm
-  command: >
-    docker exec -e KEYCLOAK_USER={{ keycloak_user }} -e KEYCLOAK_PASSWORD={{ keycloak_password }}
-    -e KEYCLOAK_IMPORT=/backup/realm.json keycloak_server
-  no_log: True

--- a/roles/keycloak/tasks/import_realm.yml
+++ b/roles/keycloak/tasks/import_realm.yml
@@ -1,0 +1,6 @@
+---
+- name: Import realm
+  command: >
+    docker exec -e KEYCLOAK_USER={{ keycloak_user }} -e KEYCLOAK_PASSWORD={{ keycloak_password }}
+    -e KEYCLOAK_IMPORT=/backup/realm.json keycloak_server
+  no_log: True


### PR DESCRIPTION
This adds support for Keystone federation in CHI-in-a-Box. By default, if Portal websso is enabled, that will still be the default, and you have to opt in via a special Horizon endpoint (`/auth/new-login-flow`) in order to get the new UI, which supports logging in either via Portal or via Keycloak.