### PR TITLE
Deploy Keycloak TAS sync as periodic task

### DIFF
--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -114,6 +114,7 @@ ironic_pxe_append_params: "nofb nomodeset vga=normal console=tty0 console=ttyS0,
 
 # Keycloak
 enable_keycloak: no
+enable_keycloak_tas_sync: no
 enable_keycloak_external: "{{ enable_keycloak }}"
 enable_keycloak_external_frontend: no
 keycloak_realm_name: chameleon

--- a/playbooks/keycloak.yml
+++ b/playbooks/keycloak.yml
@@ -1,6 +1,12 @@
 ---
-- hosts:
-    - keycloak
-    - keycloak_tas_sync
+- hosts: keycloak
   roles:
     - keycloak
+  when:
+    - enable_keycloak | bool
+
+- hosts: keycloak_tas_sync
+  roles:
+    - keycloak_tas_sync
+  when:
+    - enable_keycloak_tas_sync | bool

--- a/playbooks/keycloak.yml
+++ b/playbooks/keycloak.yml
@@ -1,4 +1,6 @@
 ---
-- hosts: keycloak
+- hosts:
+    - keycloak
+    - keycloak_tas_sync
   roles:
     - keycloak

--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -77,25 +77,3 @@ keycloak_tasks:
     group: keycloak_server
     calendar: daily
     command: "/usr/local/sbin/keycloak_backup_realm.sh {{ keycloak_realm_name }}"
-  keycloak_tas_sync:
-    group: keycloak_tas_sync
-    calendar: hourly
-    docker:
-      image: docker.chameleoncloud.org/keycloak-tas-sync:latest
-      environment:
-        LDAP_BIND_UID: "{{ keycloak_tas_sync_ldap_bind_uid }}"
-        LDAP_BIND_PASSWORD: "{{ keycloak_tas_sync_ldap_bind_password|default(omit) }}"
-        LDAP_URL: ldap://ldap.tacc.utexas.edu:389
-        TAS_URL: https://tas.tacc.utexas.edu/api
-        TAS_CLIENT_KEY: "{{ keycloak_tas_sync_tas_client_key }}"
-        TAS_CLIENT_SECRET: "{{ keycloak_tas_sync_tas_client_secret|default(omit) }}"
-        KEYCLOAK_CLIENT_ID: "{{ keycloak_tas_sync_keycloak_client_id }}"
-        KEYCLOAK_CLIENT_SECRET: "{{ keycloak_tas_sync_keycloak_client_secret|default(omit) }}"
-        KEYCLOAK_CLIENT_PROVIDER_ALIAS: "{{ keycloak_tas_sync_provider_alias }}"
-        KEYCLOAK_CLIENT_PROVIDER_SUB: "{{ keycloak_tas_sync_provider_sub }}"
-
-keycloak_tas_sync_ldap_bind_uid: cctest
-keycloak_tas_sync_tas_client_key: tasclient
-keycloak_tas_sync_keycloak_client_id: user-group-import
-keycloak_tas_sync_provider_alias: tacc
-keycloak_tas_sync_provider_sub: 6c3f8474-e0f7-49f7-9ddd-90c1b899daab

--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -71,3 +71,31 @@ keycloak_services:
       - type: volume
         src: keycloak_db_storage
         dst: /var/lib/mysql
+
+keycloak_tasks:
+  keycloak_realm_export:
+    group: keycloak_server
+    calendar: daily
+    command: "/usr/local/sbin/keycloak_backup_realm.sh {{ keycloak_realm_name }}"
+  keycloak_tas_sync:
+    group: keycloak_tas_sync
+    calendar: hourly
+    docker:
+      image: docker.chameleoncloud.org/keycloak-tas-sync:latest
+      environment:
+        LDAP_BIND_UID: "{{ keycloak_tas_sync_ldap_bind_uid }}"
+        LDAP_BIND_PASSWORD: "{{ keycloak_tas_sync_ldap_bind_password|default(omit) }}"
+        LDAP_URL: ldap://ldap.tacc.utexas.edu:389
+        TAS_URL: https://tas.tacc.utexas.edu/api
+        TAS_CLIENT_KEY: "{{ keycloak_tas_sync_tas_client_key }}"
+        TAS_CLIENT_SECRET: "{{ keycloak_tas_sync_tas_client_secret|default(omit) }}"
+        KEYCLOAK_CLIENT_ID: "{{ keycloak_tas_sync_keycloak_client_id }}"
+        KEYCLOAK_CLIENT_SECRET: "{{ keycloak_tas_sync_keycloak_client_secret|default(omit) }}"
+        KEYCLOAK_CLIENT_PROVIDER_ALIAS: "{{ keycloak_tas_sync_provider_alias }}"
+        KEYCLOAK_CLIENT_PROVIDER_SUB: "{{ keycloak_tas_sync_provider_sub }}"
+
+keycloak_tas_sync_ldap_bind_uid: cctest
+keycloak_tas_sync_tas_client_key: tasclient
+keycloak_tas_sync_keycloak_client_id: user-group-import
+keycloak_tas_sync_provider_alias: tacc
+keycloak_tas_sync_provider_sub: 6c3f8474-e0f7-49f7-9ddd-90c1b899daab

--- a/roles/keycloak/tasks/main.yml
+++ b/roles/keycloak/tasks/main.yml
@@ -9,12 +9,16 @@
     label: "{{ item.value.image }}"
   tags:
     - pull
+  when:
+    - inventory_hostname in groups[item.value.group]
 
 - name: Create Keycloak network.
   docker_network:
     name: "{{ keycloak_docker_network }}"
     ipam_config:
       - subnet: "{{ keycloak_docker_network_subnet }}"
+  when:
+    - inventory_hostname in groups.keycloak_server
 
 - name: Configure Keycloak services.
   include_role:
@@ -31,6 +35,8 @@
   loop: "{{ keycloak_services|dict2items }}"
   loop_control:
     label: "{{ item.key }}"
+  when:
+    - inventory_hostname in groups[item.value.group]
 
 - name: Configure haproxy for Keycloak
   import_role:
@@ -44,11 +50,33 @@
     src: keycloak_backup_realm.sh
     dest: /usr/local/sbin/keycloak_backup_realm.sh
     mode: "0700"
+  when:
+    - inventory_hostname in groups[keycloak_tasks.keycloak_realm_export.group]
 
-- name: Configure periodic realm export.
+- name: Pull Keycloak task images.
+  docker_image:
+    source: pull
+    name: "{{ item.value.docker.image }}"
+    force_source: yes
+  loop: "{{ keycloak_tasks|dict2items }}"
+  loop_control:
+    label: "{{ (item.value.docker | default({})).image|default(None) }}"
+  when:
+    - item.value.docker is defined
+    - inventory_hostname in groups[item.value.group]
+  tags:
+    - pull
+
+- name: Configure Keycloak periodic tasks.
   include_role:
     name: chameleon.periodic_task
   vars:
-    task_name: keycloak_backup_realm
-    task_calendar: daily
-    task_command: "/usr/local/sbin/keycloak_backup_realm.sh {{ keycloak_realm_name }}"
+    task_name: "{{ item.key }}"
+    task_calendar: "{{ item.value.calendar }}"
+    task_command: "{{ item.value.command|default(None) }}"
+    task_docker: "{{ item.value.docker|deafult(None) }}"
+  loop: "{{ keycloak_tasks|dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+  when:
+    - inventory_hostname in groups[item.value.group]

--- a/roles/keycloak/tasks/main.yml
+++ b/roles/keycloak/tasks/main.yml
@@ -74,7 +74,7 @@
     task_name: "{{ item.key }}"
     task_calendar: "{{ item.value.calendar }}"
     task_command: "{{ item.value.command|default(None) }}"
-    task_docker: "{{ item.value.docker|deafult(None) }}"
+    task_docker: "{{ item.value.docker|default(None) }}"
   loop: "{{ keycloak_tasks|dict2items }}"
   loop_control:
     label: "{{ item.key }}"

--- a/roles/keycloak_tas_sync/defaults/main.yml
+++ b/roles/keycloak_tas_sync/defaults/main.yml
@@ -1,0 +1,24 @@
+---
+keycloak_tas_sync_tasks:
+  keycloak_tas_sync:
+    group: keycloak_tas_sync
+    calendar: hourly
+    docker:
+      image: docker.chameleoncloud.org/keycloak-tas-sync:latest
+      environment:
+        LDAP_BIND_UID: "{{ keycloak_tas_sync_ldap_bind_uid }}"
+        LDAP_BIND_PASSWORD: "{{ keycloak_tas_sync_ldap_bind_password|default(omit) }}"
+        LDAP_URL: ldap://ldap.tacc.utexas.edu:389
+        TAS_URL: https://tas.tacc.utexas.edu/api
+        TAS_CLIENT_KEY: "{{ keycloak_tas_sync_tas_client_key }}"
+        TAS_CLIENT_SECRET: "{{ keycloak_tas_sync_tas_client_secret|default(omit) }}"
+        KEYCLOAK_CLIENT_ID: "{{ keycloak_tas_sync_keycloak_client_id }}"
+        KEYCLOAK_CLIENT_SECRET: "{{ keycloak_tas_sync_keycloak_client_secret|default(omit) }}"
+        KEYCLOAK_CLIENT_PROVIDER_ALIAS: "{{ keycloak_tas_sync_provider_alias }}"
+        KEYCLOAK_CLIENT_PROVIDER_SUB: "{{ keycloak_tas_sync_provider_sub }}"
+
+keycloak_tas_sync_ldap_bind_uid: cctest
+keycloak_tas_sync_tas_client_key: tasclient
+keycloak_tas_sync_keycloak_client_id: user-group-import
+keycloak_tas_sync_provider_alias: tacc
+keycloak_tas_sync_provider_sub: 6c3f8474-e0f7-49f7-9ddd-90c1b899daab

--- a/roles/keycloak_tas_sync/tasks/main.yml
+++ b/roles/keycloak_tas_sync/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+- name: Pull Keycloak TAS sync task images.
+  docker_image:
+    source: pull
+    name: "{{ item.value.docker.image }}"
+    force_source: yes
+  loop: "{{ keycloak_tas_sync_tasks|dict2items }}"
+  loop_control:
+    label: "{{ (item.value.docker | default({})).image|default(None) }}"
+  when:
+    - item.value.docker is defined
+    - inventory_hostname in groups[item.value.group]
+  tags:
+    - pull
+
+- name: Configure Keycloak TAS sync periodic tasks.
+  include_role:
+    name: chameleon.periodic_task
+  vars:
+    task_name: "{{ item.key }}"
+    task_calendar: "{{ item.value.calendar }}"
+    task_command: "{{ item.value.command|default(None) }}"
+    task_docker: "{{ item.value.docker|default(None) }}"
+  loop: "{{ keycloak_tas_sync_tasks|dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+  when:
+    - inventory_hostname in groups[item.value.group]

--- a/site-config.example/inventory/hosts
+++ b/site-config.example/inventory/hosts
@@ -730,5 +730,5 @@ keycloak
 [keycloak_db:children]
 keycloak
 
-[keycloak_tas_sync]
-# Disabled by default
+[keycloak_tas_sync:children]
+keycloak

--- a/site-config.example/inventory/hosts
+++ b/site-config.example/inventory/hosts
@@ -729,3 +729,6 @@ keycloak
 
 [keycloak_db:children]
 keycloak
+
+[keycloak_tas_sync]
+# Disabled by default


### PR DESCRIPTION
This updates the Keycloak role to also handle deploying the TAS sync
script. This should only run at one site, and it may have to run at TACC
due to firewall restrictions on some of the network endpoints needed by
the sync (Portal DB, TACC LDAP).