### PR TITLE
[horizon/heat] use trusts

### DIFF
--- a/kolla/node_custom_config/heat.conf
+++ b/kolla/node_custom_config/heat.conf
@@ -1,6 +1,7 @@
 [DEFAULT]
 auth_encryption_key = {{ heat_auth_encryption_key }}
 region_name_for_services = {{ openstack_region_name }}
+reauthentication_auth_method = trusts
 {% if keystone_primary_region_name is defined and
       keystone_primary_region_name != openstack_region_name %}
 region_name_for_domain_admin = {{ keystone_primary_region_name }}

--- a/kolla/node_custom_config/horizon/custom_local_settings
+++ b/kolla/node_custom_config/horizon/custom_local_settings
@@ -125,3 +125,10 @@ OPENSTACK_IMAGE_BACKEND = {
         ('raw', 'Raw'),
     ],
 }
+
+# The OPENSTACK_HEAT_STACK has the only setting available - enable_user_pass,
+# which can be used to disable the password field while launching the stack.
+# Set to False if HEAT uses trusts by default otherwise it needs to be set as True.
+OPENSTACK_HEAT_STACK = {
+    'enable_user_pass': False
+}


### PR DESCRIPTION
After Killo, the Identity trusts authorization model is enabled for the Orchestration service by default. So just need to disable the password field in Horizon. Tested creating a stack with 1) Horizon and 2) with openstack CLI using the new RC file (CLI password).