### PR TITLE
[allocations] Portal-compatible deployment

### DIFF
--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -162,6 +162,14 @@ nova_admin_endpoint: "{{ admin_protocol }}://{{ kolla_internal_fqdn }}:{{ nova_a
 nova_internal_endpoint: "{{ internal_protocol }}://{{ kolla_internal_fqdn }}:{{ nova_api_port }}/v2.1"
 nova_public_endpoint: "{{ public_protocol }}://{{ kolla_external_fqdn }}:{{ nova_api_port }}/v2.1"
 
+# Portal
+enable_portal: no
+# This should be in defaults b/c it may be used by other roles,
+# not just the portal role
+portal_nginx_conf_dir: /opt/chameleon/conf.d
+# The docker-compose network name for the Portal stack
+portal_network: portal
+
 # Prometheus
 enable_prometheus: no
 prometheus_bind_address: "{{ lookup('vars', 'ansible_' + network_interface).ipv4.address }}"

--- a/playbooks/prometheus.yml
+++ b/playbooks/prometheus.yml
@@ -7,6 +7,7 @@
     - prometheus-node-exporter
     - prometheus-openstack-exporter
     - prometheus-push-gateway
+    - prometheus-redis-exporter
   roles:
     - chameleon_prometheus
   tasks:

--- a/roles/allocations/defaults/main.yml
+++ b/roles/allocations/defaults/main.yml
@@ -1,15 +1,46 @@
 ---
 allocations_config_path: /etc/allocations
-allocations_docker_network: allocations
-allocations_docker_network_subnet: 172.18.11.0/24
 # Corresponds to the default user 1001 used in s2i builds
 allocations_user: 1001
 
-allocations_balance_service_docker_image: docker.chameleoncloud.org/allocations/balance-service:latest
-allocations_balance_service_name: allocations-balance-service
-allocations_balance_service_port: 8915
+allocations_api_debug: False
+allocations_api_tag: latest
+allocations_api_docker_image: "docker.chameleoncloud.org/allocations/balance-service:{{ allocations_api_tag }}"
+allocations_api_port: 8080
+# Will be exposed on localhost on host for convenience
+allocations_external_api_port: 8915
+
+allocations_db_tag: 6
+allocations_db_docker_image: "redis:{{ allocations_db_tag }}"
+allocations_db_host: allocations_db  # the Docker container name
+allocations_db_port: 6379
 
 redis_host: chi.uc.chameleoncloud.org
-allocations_auth_users: 
+allocations_auth_users:
   - blazar
   - portal
+
+allocations_services:
+  allocations_api:
+    group: allocations
+    enabled: true
+    image: "{{ allocations_api_docker_image }}"
+    network: "{{ portal_network }}"
+    ports:
+      - "{{ allocations_external_api_port }}:{{ allocations_api_port }}/tcp"
+    mounts:
+      - type: bind
+        src: "{{ allocations_config_path }}/service.conf"
+        dst: /etc/allocations/balance-service.conf
+  allocations_db:
+    group: allocations
+    enabled: true
+    image: "{{ allocations_db_docker_image }}"
+    network: "{{ portal_network }}"
+    ports:
+      - "{{ allocations_db_port }}:{{ allocations_db_port }}"
+    mounts:
+      - type: volume
+        src: allocations_db
+        dst: /data
+    command: redis-server --appendonly yes

--- a/roles/allocations/handlers/main.yml
+++ b/roles/allocations/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: "restart allocations balance service"
+- name: restart allocations api
   service:
-    name: "{{ allocations_balance_service_name }}"
+    name: allocations_api
     state: restarted

--- a/roles/allocations/tasks/main.yml
+++ b/roles/allocations/tasks/main.yml
@@ -1,45 +1,73 @@
 ---
-- name: Pull allocations service container images.
+- name: Pull allocations API image.
   docker_image:
     source: pull
-    name: "{{ item }}"
+    name: "{{ allocations_api_docker_image }}"
     state: present
     force_source: yes
-  loop:
-    - "{{ allocations_balance_service_docker_image }}"
   notify:
-    - restart allocations balance service
+    - restart allocations api
   tags:
     - pull
-    
-- name: Create Docker network.
-  docker_network:
-    name: "{{ allocations_docker_network }}"
-    ipam_config:
-      - subnet: "{{ allocations_docker_network_subnet }}"
+  when:
+    - inventory_hostname in groups['allocations']
+
+- name: Pull allocations DB image.
+  docker_image:
+    source: pull
+    name: "{{ allocations_db_docker_image }}"
     state: present
-  when: allocations_docker_network != "host"
+    force_source: yes
+  tags:
+    - pull
+  when:
+    - inventory_hostname in groups['allocations']
 
-- name: Create init configuration.
-  template:
-    src: "allocations_balance_service.conf.j2"
-    mode: 0600
-    dest: "{{ allocations_config_path }}/service.conf"
-    owner: "{{ allocations_user }}"
-  notify:
-    - restart allocations balance service
+- name: Create API configuration.
+  block:
+    - name: Ensure configuration directory exists
+      file:
+        name: "{{ allocations_config_path }}"
+        state: directory
+    - name: Create API configuration.
+      template:
+        src: allocations_balance_service.conf.j2
+        mode: "0600"
+        dest: "{{ allocations_config_path }}/service.conf"
+        owner: "{{ allocations_user }}"
+      notify:
+        - restart allocations api
+  when:
+    - inventory_hostname in groups['allocations']
 
-- name: Configure allocations services
+- name: Create Nginx configuration
+  block:
+    - name: Ensure Nginx includes directory exists
+      file:
+        name: "{{ portal_nginx_conf_dir }}/includes"
+        state: directory
+    - name: Create Nginx configuration
+      template:
+        src: nginx.conf.j2
+        dest: "{{ portal_nginx_conf_dir }}/includes/portal_allocations.conf"
+  when:
+    - enable_portal | bool
+    - inventory_hostname in groups['portal']
+
+- name: Configure allocations services.
   include_role:
     name: chameleon.docker_service
   vars:
-    service_name: "{{ allocations_balance_service_name }}"
-    service_bind_address: "{{ api_interface_address }}"
-    docker_image: "{{ allocations_balance_service_docker_image }}"
-    docker_network: "{{ allocations_docker_network }}"
-    docker_mounts: 
-      - type: bind
-        src: "{{ allocations_config_path }}/service.conf"
-        dst: "/etc/allocations/balance-service.conf"
-    docker_ports: 
-      - "{{ api_interface_address }}:{{ allocations_balance_service_port }}:8080/tcp"
+    service_name: "{{ item.key }}"
+    service_bind_address: 127.0.0.1
+    docker_image: "{{ item.value.image }}"
+    docker_network: "{{ item.value.network|default('bridge') }}"
+    docker_environment: "{{ item.value.environment|default({}) }}"
+    docker_mounts: "{{ item.value.mounts|default([]) }}"
+    docker_ports: "{{ item.value.ports|default([]) }}"
+    docker_command: "{{ item.value.command|default('') }}"
+  loop: "{{ allocations_services|dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+  when:
+    - inventory_hostname in groups[item.value.group]

--- a/roles/allocations/templates/allocations_balance_service.conf.j2
+++ b/roles/allocations/templates/allocations_balance_service.conf.j2
@@ -1,10 +1,10 @@
 [DEFAULT]
-debug: False
+debug: {{ allocations_api_debug | bool }}
 
 [serviceaccount]
 auth_url: {{ keystone_public_url }}/v3
 auth_users: {{ allocations_auth_users | join(",") }}
 
 [redis]
-host: {{ redis_host }}
-port: {{ redis_port }}
+host: {{ allocations_db_host }}
+port: {{ allocations_db_port }}

--- a/roles/allocations/templates/nginx.conf.j2
+++ b/roles/allocations/templates/nginx.conf.j2
@@ -1,0 +1,16 @@
+location /allocations/ {
+  # Using a variable prevents Nginx from crashing out if the hostname cannot
+  # be resolved at start time.
+  set $upstream http://allocations_api:{{ allocations_api_port }};
+  # NOTE(jason): when using a variable for the upstream address, Nginx will
+  # require a resolver is explicitly set ;_; - it cannot automatically pick up
+  # the resolver in /etc/resolv.conf apparently. Set this explicitly to the
+  # Docker default nameserver.
+  resolver 127.0.0.11;
+  # When using variables in proxy_pass, it will not automatically pass through
+  # the request URI, so we have to construct it ourselves.
+  if ($request_uri ~* "/allocations(/.*$)") {
+    set $path $1;
+  }
+  proxy_pass $upstream$path;
+}

--- a/roles/chameleon_prometheus/defaults/main.yml
+++ b/roles/chameleon_prometheus/defaults/main.yml
@@ -85,6 +85,18 @@ prometheus_services:
     scrape_target: yes
     volumes:
       - "/etc/prometheus/openstack_exporter.yml:/usr/local/bin/exporter/config.yml"
+  redis-exporter:
+    service_name: prometheus_redis_exporter
+    image: oliver006/redis_exporter:latest
+    group: prometheus-redis-exporter
+    restart_handler: restart redis exporter
+    port: 9121
+    scrape_target: yes
+    service_args:
+      # TODO(jason): this is a complete hack and means this configuration is
+      # ONLY valid for the allocations DB. But, it's currently the only place
+      # we use Redis.
+      - "--redis.addr=redis://allocations_db:6379"
   snmp-exporter:
     service_name: prometheus_snmp_exporter
     image: prom/snmp-exporter:v0.15.0

--- a/roles/chameleon_prometheus/handlers/main.yml
+++ b/roles/chameleon_prometheus/handlers/main.yml
@@ -42,3 +42,8 @@
   service:
     name: prometheus_pushgateway
     state: restarted
+
+- name: restart redis exporter
+  service:
+    name: prometheus_redis_exporter
+    state: restarted

--- a/roles/chameleon_prometheus/templates/prometheus.yml.j2
+++ b/roles/chameleon_prometheus/templates/prometheus.yml.j2
@@ -19,7 +19,7 @@ rule_files:
   - '/etc/prometheus/rules/*.yml'
 
 scrape_configs:
-{% for name, service in prometheus_services.iteritems() %}
+{% for name, service in prometheus_services.items() %}
 {% if service.scrape_target | bool and groups[service.group] | length > 0 %}
 - job_name: '{{ name }}'
 {% if service.scrape_interval is defined %}

--- a/site-config.example/inventory/hosts
+++ b/site-config.example/inventory/hosts
@@ -821,6 +821,9 @@ monitoring
 [prometheus-push-gateway:children]
 monitoring
 
+[prometheus-redis-exporter:children]
+redis
+
 [prometheus-snmp-exporter:children]
 monitoring
 


### PR DESCRIPTION
This sets up the allocation service to live alongside the portal
infrastructure (portal Django app and resource API). To do so, it adds a
few additional configuration options which default to off, notably
enable_portal. When portal is enabled, the playbook will ensure an Nginx
configuration is included to route requests to the allocations service.