### PR TITLE
[keycloak] Add support for deploying custom extensions

### DIFF
--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -41,6 +41,9 @@ keycloak_services:
       - type: volume
         src: keycloak_backup
         dst: /backup
+      - type: bind
+        src: "{{ keycloak_extension_path }}"
+        dst: /opt/jboss/keycloak/standalone/deployments
     command: >
       -b 0.0.0.0
       -c standalone.xml
@@ -78,3 +81,13 @@ keycloak_tasks:
     group: keycloak_server
     calendar: daily
     command: "/usr/local/sbin/keycloak_backup_realm.sh {{ keycloak_realm_name }}"
+
+keycloak_extension_path: /etc/keycloak/modules
+keycloak_extension_repository_username: chameleoncloud-ci
+keycloak_extensions:
+  - group_id: org.chameleoncloud
+    artifact_id: keycloak-chameleon
+    version: 1.0.0-SNAPSHOT
+    username: "{{ keycloak_extension_repository_username }}"
+    password: "{{ keycloak_extension_repository_password }}"
+    repository_url: https://maven.pkg.github.com/ChameleonCloud

--- a/roles/keycloak/tasks/main.yml
+++ b/roles/keycloak/tasks/main.yml
@@ -12,6 +12,27 @@
   when:
     - inventory_hostname in groups[item.value.group]
 
+- name: Pull Keycloak extensions
+  block:
+    - name: Create extension directory
+      file:
+        name: "{{ keycloak_extension_path }}"
+        state: directory
+        mode: "0775"  # Keycloak needs to write metadata files to this directory
+    - name: Fetch extension jar files
+      maven_artifact:
+        group_id: "{{ item.group_id }}"
+        artifact_id: "{{ item.artifact_id }}"
+        version: "{{ item.version }}"
+        repository_url: "{{ item.repository_url }}"
+        username: "{{ item.username }}"
+        password: "{{ item.password }}"
+        mode: "0644"
+        # Name after artifact to ensure only 1 version of each artifact
+        # can be loaded at a time.
+        dest: "{{ keycloak_extension_path }}/{{ item.artifact_id }}.jar"
+      loop: "{{ keycloak_extensions }}"
+
 - name: Create Keycloak network.
   docker_network:
     name: "{{ keycloak_docker_network }}"


### PR DESCRIPTION
Keycloak supports placing JAR files in a special directory and hotloading them (loading the code w/o restarting the server.) It's pretty nifty. Pull our custom extension from GitHub packages and put it in the magic directory. Changes to the extension can happen by bumping the version.