### PR TITLE
[allocations] Updates for Balance Service Usage Enforcment

### DIFF
--- a/roles/allocations/defaults/main.yml
+++ b/roles/allocations/defaults/main.yml
@@ -2,6 +2,8 @@
 allocations_config_path: /etc/allocations
 # Corresponds to the default user 1001 used in s2i builds
 allocations_user: 1001
+allocations_project_enforcement_id: charge_code
+allocations_usage_default_allocated: 20000.0
 
 allocations_api_debug: False
 allocations_api_tag: latest
@@ -19,6 +21,11 @@ redis_host: chi.uc.chameleoncloud.org
 allocations_auth_users:
   - blazar
   - portal
+allocations_allowed_auth_urls:
+  - https://chi.uc.chameleoncloud.org:5000/v3
+  - https://chi.tacc.chameleoncloud.org:5000/v3
+  - https://dev.uc.chameleoncloud.org:5000/v3
+  - https://dev.tacc.chameleoncloud.org:5000/v3
 
 allocations_services:
   allocations_api:
@@ -31,7 +38,8 @@ allocations_services:
     mounts:
       - type: bind
         src: "{{ allocations_config_path }}/service.conf"
-        dst: /etc/allocations/balance-service.conf
+        dst: /etc/allocations/service.conf
+    command: python balance_service/app.py
   allocations_db:
     group: allocations
     enabled: true

--- a/roles/allocations/templates/allocations_balance_service.conf.j2
+++ b/roles/allocations/templates/allocations_balance_service.conf.j2
@@ -2,9 +2,14 @@
 debug: {{ allocations_api_debug | bool }}
 
 [serviceaccount]
-auth_url: {{ keystone_public_url }}/v3
+default_auth_url: {{ keystone_public_url }}/v3
+allowed_auth_urls: {{ allocations_allowed_auth_urls | join(",") }}
 auth_users: {{ allocations_auth_users | join(",") }}
 
 [redis]
 host: {{ allocations_db_host }}
 port: {{ allocations_db_port }}
+
+[enforcement]
+project_enforcement_id: {{ allocations_project_enforcement_id }}
+usage_default_allocated: {{ allocations_usage_default_allocated }}


### PR DESCRIPTION
The allocations service now handles usage enforcement via the
external service filter in Blazar. Edits here include adding
usage enforcement configs and an allowed_auth_urls variable to
enable balance service to authenticate against multiple keystone
urls.