### PR TITLE
Override external cert directory to be in site-configs

### DIFF
--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -62,6 +62,7 @@ enable_haproxy: yes
 kolla_enable_tls_external: yes
 haproxy_listen_neutron_server_extra: ["timeout server 15m"]
 haproxy_service_template: "haproxy_single_service_split.cfg.j2"
+kolla_external_fqdn_cert: "{{ cc_ansible_site_dir }}/certificates/haproxy.pem"
 
 # Heat
 enable_heat: yes


### PR DESCRIPTION
This is why the wiki instructions never seemed to work.