### PR TITLE
add pipelining and more forks to ansible cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,4 +1,6 @@
 [defaults]
+pipelining=True
+forks=100
 # Ensure that ansible can find roles relative to its working directory
 # (instead of looking within playbooks directory or default paths)
 roles_path = ./roles:./roles/galaxy.ansible.com


### PR DESCRIPTION
The [Kolla-Ansible Quickstart](https://docs.openstack.org/kolla-ansible/latest/user/quickstart.html#configure-ansible) mentions some speed improvements for ansible.

"forks" allows operations to execute on more machines in parallel.

[pipelining](https://docs.ansible.com/ansible/latest/reference_appendices/config.html#ansible-pipelining) allows more actions to be taken over SSH without initiating a new transfer, but may depend on sudoers config.

