### PR TITLE
Bugfix/centos8-compat

### DIFF
--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -139,8 +139,6 @@ keycloak_url: "https://{{ keycloak_hostname }}"
 
 # Keystone
 enable_keystone: yes
-use_preconfigured_fernet: yes
-fernet_token_expiry: 604800 # 1 week
 keystone_admin_project: openstack
 # The following are needed for defaults for the Glance/Gnocchi backup roles
 # (site-configs derive from these)

--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -8,6 +8,10 @@ docker_registry: docker.chameleoncloud.org
 kolla_base_distro: centos
 kolla_install_type: source
 
+# Disable addition of tag for CentOS8
+# Remove this if pulling CentOS8 containers
+openstack_tag_suffix: ''
+
 virtualenv: /etc/ansible/venv
 
 chameleon_portal_url: https://www.chameleoncloud.org

--- a/kolla/node_custom_config/horizon/clouds.yaml.template
+++ b/kolla/node_custom_config/horizon/clouds.yaml.template
@@ -23,7 +23,7 @@ clouds:
 {% endraw %}
       identity_provider: {{ identity_provider_name }}
       discovery_endpoint: {{ identity_provider_url }}/.well-known/openid-configuration
-      client_id: {{ keystone_idp_client_id }}
+      client_id: {{ keystone_idp_client_id|default(none) }}
       access_token_type: access_token
 {%- raw %}
       client_secret: none

--- a/kolla/node_custom_config/horizon/custom_local_settings
+++ b/kolla/node_custom_config/horizon/custom_local_settings
@@ -136,7 +136,7 @@ WEBSSO_DEFAULT_REDIRECT_PROTOCOL = 'openid'
 # parameter set to a valid redirect URI, the user's session will be cleared both
 # within the mod_auth_openidc session cache, but also on the authenticating
 # provider itself. We redirect to the custom post-logout page.
-WEBSSO_DEFAULT_REDIRECT_LOGOUT = '{{ keystone_public_url }}/redirect_uri?logout={{ (identity_provider_url ~ "/post-logout?client_id=" ~ keystone_idp_client_id) | urlencode }}'
+WEBSSO_DEFAULT_REDIRECT_LOGOUT = '{{ keystone_public_url }}/redirect_uri?logout={{ (identity_provider_url ~ "/post-logout?client_id=" ~ (keystone_idp_client_id|default(none)) ) | urlencode }}'
 
 {% if enable_horizon_chameleon_websso | bool %}
 AUTHENTICATION_URLS = ['openstack_dashboard.cc_web_sso_urls', 'openstack_auth.urls']

--- a/kolla/node_custom_config/horizon/openrc.sh.template
+++ b/kolla/node_custom_config/horizon/openrc.sh.template
@@ -14,7 +14,7 @@ export OS_PASSWORD=$OS_PASSWORD_INPUT
 {% endraw %}
 export OS_IDENTITY_PROVIDER="{{ identity_provider_name }}"
 export OS_DISCOVERY_ENDPOINT="{{ identity_provider_url }}/.well-known/openid-configuration"
-export OS_CLIENT_ID="{{ keystone_idp_client_id }}"
+export OS_CLIENT_ID="{{ keystone_idp_client_id|default(none) }}"
 export OS_ACCESS_TOKEN_TYPE="access_token"
 {% raw -%}
 export OS_CLIENT_SECRET="none"

--- a/site-config.example/globals.yml
+++ b/site-config.example/globals.yml
@@ -19,6 +19,13 @@ kolla_external_vip_address: 100.0.0.1
 kolla_external_fqdn: chi.example.com
 
 
+
+#Uncomment to Disable Federated Auth
+# enable_keystone_federation: no
+# enable_keystone_federation_openid: no
+# keystone_idp_client_id: null
+
+
 # Neutron networks (MANDATORY)
 # Uncomment to enable Neutron Bridge Networks
 # At least one private and one public is required

--- a/site-config.example/globals.yml
+++ b/site-config.example/globals.yml
@@ -1,48 +1,68 @@
 ---
+# This file contains an example site configuration.
+# To enable features, each section MUST be customized to you needs.
+
+# Associate Site Name (MANDATORY)
 openstack_region_name: CHI@XYZ
 # Site name, similar to region but used for out-of-band inventory management
 chameleon_site_name: xyz
 
-# Networking
+# HAProxy Config (MANDATORY)
+enable_haproxy: yes
+# Provide a full TLS chain in /etc/kolla/haproxy/certs.d/
+kolla_enable_tls_external: yes
+# Set to a "spare" address in the "internal" subnet
 kolla_internal_vip_address: 10.0.0.1
+# Set to a "spare" address in the "public" subnet
 kolla_external_vip_address: 100.0.0.1
+# This should resolve to the external_vip and match the TLS Cert
 kolla_external_fqdn: chi.example.com
 
-neutron_networks:
-  physnet1:
-    on_demand_vlan_ranges:
-      - 200:250
-    reservable_vlan_ranges:
-      - 250:300
-    bridge_name: br-em1
-    external_interface: em1
-  physnet2:
-    bridge_name: br-em2
-    external_interface: em2
-  public:
-    bridge_name: br-ex
-    external_interface: em3
-    # This should be your public IP block assigned to your deployment.
-    cidr: 0.0.0.0/32
 
-ironic_provisioning_network_vlan: 200
+# Neutron networks (MANDATORY)
+# Uncomment to enable Neutron Bridge Networks
+# At least one private and one public is required
+# neutron_networks:
+#   - name: physnet1
+#     on_demand_vlan_ranges:
+#       - 200:250
+#     reservable_vlan_ranges:
+#       - 250:300
+#     bridge_name: br-em1
+#     external_interface: em1
+#   - name: physnet2
+#     bridge_name: br-em2
+#     external_interface: em2
+#   - name: public
+#     bridge_name: br-ex
+#     external_interface: em3
+#     # This should be your public IP block assigned to your deployment.
+#     cidr: 0.0.0.0/32
 
-switch_configs:
-  - name: leafswitch1
-    device_type: netmiko_dell_force10
-    address: 10.0.0.10
-    auth:
-      username: chameleon
-      password: "{{ dell_switch_password }}"
-    snmp:
-      community_string: "{{ dell_switch_community_string }}"
-    ngs_config:
-      persist_changes: False
-      fast_cli: True
+
+# Ironic network config
+# Uncomment to enable provisioning vlan for Ironic
+# ironic_provisioning_network_vlan: 200
+# ironic_dnsmasq_dhcp_range: 10.51.0.0/24
+
+# Physical Switch config for Neutron-ML2:
+# Uncomment with info for neutron managed switch
+#   - name: leafswitch1
+#     device_type: netmiko_dell_force10
+#     address: 10.0.0.10
+#     auth:
+#       username: chameleon
+#       password: "{{ dell_switch_password }}"
+#     snmp:
+#       community_string: "{{ dell_switch_community_string }}"
+#     ngs_config:
+#       persist_changes: False
+#       fast_cli: True
 
 # If you are allowing users to reserve public IPs,
 # this should correspond to the Neutron ID of your
 # public (gateway) network.
 #blazar_floatingip_reservation_network_id: 687976bc-e93f-4c47-ac21-fbd341313a54
 
-prometheus_alertmanager_hostname: "{{ kolla_external_fqdn }}"
+# Uncomment to enable prometheus alertmanager
+# prometheus_alertmanager_hostname: "{{ kolla_external_fqdn }}"


### PR DESCRIPTION
Upstream has introduced a number of changes for centos8, which require the use of centos8 containers on a centos8 host.

This draft PR is holding changes I add to get `./cc-ansible deploy` to run successfully on a centos8 host.