### PR TITLE
add system and 64 bit counter OIDs to snmp scrape

### DIFF
--- a/roles/chameleon_prometheus/templates/snmp_generator.yml.j2
+++ b/roles/chameleon_prometheus/templates/snmp_generator.yml.j2
@@ -5,10 +5,24 @@ modules:
   {% if switch.device_type not in device_types %}
   {{ device_types.append(switch.device_type) }}
   {{ switch.device_type }}:
-    walk:
-      - interfaces
-    version: 1
+    version: 2
     auth:
       community: {{ switch.snmp.community_string }}
+    walk:
+      - system
+      - interfaces
+      - ifXTable
+    lookups:
+      - source_indexes: [ifIndex]
+        lookup: ifName
+    overrides:
+      ifAlias:
+        ignore: true # Lookup metric
+      ifDescr:
+        ignore: true # Lookup metric
+      ifName:
+        ignore: true # Lookup metric
+      ifType:
+        type: EnumAsInfo
   {% endif %}
 {% endfor %}


### PR DESCRIPTION
32bit counter issue:

interfaces comes from snmp MIB-2, and uses 32bit counters for octets and packet counts.
This will overflow and wrap around very quickly on any modern link. In particular, 
[rfc2863](https://datatracker.ietf.org/doc/html/rfc2863#section-3.1.6) mentions:
> at 1Gbs, the minimum is 34 seconds

We're running 100Gb/s links, and polling once per 120 seconds.

This change adds scraping of the ifXTable, from IF-MIB, which resolves this with 64bit counters.
In particular, prefer "ifHC*" to "if*" metrics, HC standing for "high capacity".


To assist in human readable metrics, this change also scrapes a subset of:
- ifName
- ifDescr
- ifAlias

and attempts to map them to ifIndex. Which one should be used is vendor specific.


Finally, scraping the "system" OID will provide uniquely identifying information for the target.
An example of the relevant information is below.

```
sysDescr:   Dell Networking OS
            Operating System Version: 2.0
            Application Software Version: 9.8(0.0)
            Series: S6000-ON
            Copyright (c) 1999-2015 by Dell Inc. All Rights Reserved.
            Build Time: Fri May 15 00:25:50 2015
sysObjectID: DELL-NETWORKING-PRODUCTS-MIB::s4048on
sysUpTime: 225 days, 5:22:48.52
sysContact:
sysName: Chameleon-Compute
sysLocation:

