### PR TITLE
add missing password for federation

### DIFF
--- a/site-config.example/passwords.yml
+++ b/site-config.example/passwords.yml
@@ -8,6 +8,7 @@ blazar_database_password:
 blazar_keystone_password:
 keystone_admin_password:
 keystone_database_password:
+keystone_federation_openid_crypto_password:
 grafana_database_password:
 grafana_admin_password:
 glance_database_password:


### PR DESCRIPTION
keystone_federation_openid_crypto_password was missing from the example passwords.yml, so it didn't get generated following the wiki.