### PR TITLE
fix typo, rule:admin -> role:admin

### DIFF
--- a/kolla/node_custom_config/blazar/policy.json
+++ b/kolla/node_custom_config/blazar/policy.json
@@ -4,7 +4,7 @@
     "admin_or_owner":  "rule:admin or project_id:%(project_id)s",
 
     "default": "!",
-    "admin_api": "rule:admin",
+    "admin_api": "role:admin",
 
     "blazar:leases:get": "rule:admin_or_owner",
     "blazar:leases:create": "rule:admin_or_owner",

--- a/kolla/node_custom_config/nova/policy.json
+++ b/kolla/node_custom_config/nova/policy.json
@@ -1,7 +1,7 @@
 {
-  "compute:servers:create:requested_destination": "role:osg or rule:admin",
+  "compute:servers:create:requested_destination": "role:osg or role:admin",
   "os_compute_api:os-aggregates:show": "role:osg or rule:admin_or_owner",
   "os_compute_api:os-extended-server-attributes": "rule:admin_or_owner",
-  "os_compute_api:os-flavor-extra-specs:create": "role:osg or rule:admin",
+  "os_compute_api:os-flavor-extra-specs:create": "role:osg or role:admin",
   "os_compute_api:os-hypervisors": "role:osg or rule:admin_or_owner"
 }


### PR DESCRIPTION
fix typo in policy to allow post-deploy to run as admin.

Definitions can be found at https://github.com/openstack/nova/blob/stable/train/nova/policies/base.py

Applying this change requires:

1. git pull
1. cc-ansible deploy
1. cc-ansible post-deploy