### PR TITLE
snmp-generator-image: use kolla-ansible variable

### DIFF
--- a/roles/chameleon_prometheus/defaults/main.yml
+++ b/roles/chameleon_prometheus/defaults/main.yml
@@ -19,6 +19,8 @@ prometheus_mysql_exporter_user: mysqld-exporter
 
 prometheus_openstack_exporter_user: admin
 
+prometheus_snmp_exporter_generator_image: prom/snmp-generator:master
+
 prometheus_services:
   server:
     service_name: prometheus_server
@@ -97,7 +99,7 @@ prometheus_services:
   snmp-exporter:
     service_name: prometheus_snmp_exporter
     image: prom/snmp-exporter:v0.15.0
-    generator_image: prom/snmp-generator:master
+    generator_image: {{ prometheus_snmp_exporter_generator_image }}
     group: prometheus-snmp-exporter
     enabled: yes
     restart_handler: restart snmp exporter


### PR DESCRIPTION
kolla-ansible's prometheus roles use the variable
`prometheus_snmp_exporter_generator_image`, while the chi-in-a-box roles
use: `snmp-exporter.generator_image`

kolla-ansible usage:
ansible/roles/prometheus/defaults/main.yml

chi-in-a-box usage:
roles/chameleon_prometheus/defaults/main.yml

not setting the former looks for an image built by kolla,
which we don't generate.