### PR TITLE
add v3 to auth url, since we need it?

### DIFF
--- a/kolla/node_custom_config/horizon/clouds.yaml.template
+++ b/kolla/node_custom_config/horizon/clouds.yaml.template
@@ -17,7 +17,7 @@ clouds:
   {% if user.is_federated %}
     auth_type: v3oidcpassword
     auth:
-      auth_url: {{ auth_url }}
+      auth_url: {{ auth_url }}/v3
       username: "{{ user.username }}"
       protocol: openid
 {% endraw %}


### PR DESCRIPTION
v3 doesn't appear to be included in the auth_url variable
not having this will cause a 404 when connecting with the v3oidcpassword auth_type