### PR TITLE
set ansible_python_interpreter during bootstrap

### DIFF
--- a/cc-ansible
+++ b/cc-ansible
@@ -360,6 +360,16 @@ kolla_args+=(--passwords="$CONFIG_DIR/passwords.yml")
 kolla_args+=(--extra node_custom_config="$CONFIG_DIR/node_custom_config")
 kolla_args+=(--extra cc_ansible_site_dir="$CONFIG_DIR")
 
+# We set ansible ansible_python_interpreter to the virtualenv inside site-config, and override here during bootstrap.
+# Overriding at the CLI here applies to all hosts, including the deploy host.
+# Bootstrap-servers creates a virtualenv at $VIRTUALENV, on all hosts except the deploy host, requiring a special case.
+# The old behavior was to set it here if NOT bootstrapping, but that fails for the deploy-host case.
+
+if [[ "${POSARGS[*]}" =~ bootstrap-servers ]]; then
+  # Assume python3 can be found in $PATH, only used for creating the virtualenv.
+  kolla_args+=(--extra ansible_python_interpreter="python3")
+fi
+
 if [[ "${POSARGS[*]}" =~ post-deploy ]]; then
   cp -f "$DIR/playbooks/post_deploy.yml" "$ansible_path/chi_in_a_box_post_deploy.yml"
   kolla_args+=(--extra post_deploy_extra_play="chi_in_a_box_post_deploy.yml")

--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -12,7 +12,11 @@ kolla_install_type: source
 # Remove this if pulling CentOS8 containers
 openstack_tag_suffix: ''
 
+# Set according to https://docs.openstack.org/kolla-ansible/latest/user/virtual-environments.html#target-hosts
+# virtualenv specifies the path to the kolla virtualenv, while ansible_python_interpreter must be set explicitly
+# since it cannot be templated. This is overridden during bootstrap by cc-ansible.
 virtualenv: /etc/ansible/venv
+ansible_python_interpreter: /etc/ansible/venv/bin/python
 
 chameleon_portal_url: https://www.chameleoncloud.org
 chameleon_reference_api_url: https://api.chameleoncloud.org


### PR DESCRIPTION
set the path during bootstrap to allow creation of virtualenv.

This is the "inverse" of the old behavior where we set it during "not bootstrap", but allows us to set a default in group vars, then override here.