### PR TITLE
Rename MaxReservationLengthFilter to MaxLeaseDurationFilter

### DIFF
--- a/kolla/node_custom_config/blazar.conf
+++ b/kolla/node_custom_config/blazar.conf
@@ -6,7 +6,7 @@ os_region_name = {{ openstack_region_name }}
 exempt_projects = {% for project_id in blazar_usage_project_exemptions %}{{ project_id }}{% if not loop.last %},{% endif %}{% endfor %}
 
 {% if enable_blazar_allocation_enforcement | bool %}
-enabled_filters = MaxReservationLengthFilter, ExternalServiceFilter
+enabled_filters = MaxLeaseDurationFilter, ExternalServiceFilter
 {% if blazar_external_service_endpoint is defined %}
 external_service_endpoint = {{ blazar_external_service_endpoint }}
 {% endif %}
@@ -20,9 +20,9 @@ external_service_check_update = {{ blazar_external_service_check_update_endpoint
 external_service_on_end = {{ blazar_external_service_on_end_endpoint }}
 {% endif %}
 {% else %}
-enabled_filters = MaxReservationLengthFilter
+enabled_filters = MaxLeaseDurationFilter
 {% endif %}
-max_reservation_length = {{ blazar_default_max_lease_duration }}
+max_lease_duration = {{ blazar_default_max_lease_duration }}
 reservation_extension_window = {{ blazar_default_reservation_extension_window }}
 
 [keystone_authtoken]


### PR DESCRIPTION
This was renamed when pushed upstream, but the old name `MaxReservationLengthFilter` was still used in our fork.