### PR TITLE
Bugfix/ipmi exporter defaults

### DIFF
--- a/site-config.example/inventory/hosts
+++ b/site-config.example/inventory/hosts
@@ -828,6 +828,9 @@ elasticsearch
 [prometheus-blackbox-exporter:children]
 monitoring
 
+[prometheus-ipmi-exporter:children]
+ironic-conductor
+
 [masakari-api:children]
 control
 


### PR DESCRIPTION
This fixes a missing inventory group, but still depends on changes in https://github.com/ChameleonCloud/kolla-ansible/pull/20 for CI to succeed.