### PR TITLE
Fix/contributors

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,2 @@
+# Please don't be mean
+really.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,2 +1,133 @@
-# Please don't be mean
-really.
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[INSERT CONTACT METHOD].
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,5 @@
 # Contributing to CHI-in-a-box
 
-Thank you! Read on.
-
 ## Code of Conduct
 
 This project and everyone participating in it is governed by the [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,14 +22,34 @@ We have an official message board where the community can chime in.
 CHI-in-a-box is a packaging of Openstack, using heavy customization and templating via Ansible.
 At a minimum, you should be familiar with the Linux commandline, and some basics of system administration. Knowledge of the general architecture of OpenStack will make your life much easier.
 
+While our goal is ease of use and "Operator Ergonomics", this is fundamentally a complex system with many features, so be prepared to do a lot of learning if you're new to the concepts.
+
 ## How can I Contibute?
+
+In rough order from least to most involved:
+
+### Join the [discussions](https://github.com/ChameleonCloud/chi-in-a-box/discussions)!
+Even if you don't contribute code, participating in the community, asking questions, and responding to others is enormously helpful. This helps us gauge interest in new features, and makes it possible to discover common issues that others have encountered.
 
 ### Reporting Bugs
 
+If you encounter issues, please ask on the discussion forum first. We may ask you to file a bug in order to track the details better. That said, if anything is unclear, or you don't know where to go next, we consider this a bug in the documentation, and worthy of fixing.
+
+When you do file an issue, please include:
+- What you're trying to accomplish (overall goal)
+- Any specific error messages
+- What OS you're deploying on
+
 ### Suggesting Enhancements
+
+Openstack has many features, and it's impossible for us to robustly support everything. Please post on the discussion forum about what you'd like to accomplish, and what features are missing that would make it possible / easier.
 
 ### Local Development
 
+Local development depends on having a running Chi-in-a-box site. You can follow the Quickstart guide to bring one up on your own hardware, or, if you have a Chameleon account already, use our [Trovi Artifact](https://chameleoncloud.org/experiment/share/35) to run a development node on top of another Chameleon site.
+
 ### Pull Requests
 
-### Issues and Pull Request Labels
+Submitting a pull request will trigger our CI, including some basic linting, as well as sanity checks around deployment use-cases.
+Please be clear about the intended deployment scenario, as we'll need to ensure it doesn't break anything for existing deployments.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing to CHI-in-a-box
+
+Thank you! Read on.
+
+## Code of Conduct
+
+This project and everyone participating in it is governed by the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## I don't want to read this whole thing I just have a question!!!
+
+> Please don't file an issue just to ask a question. You'll get faster results with one of the folowing:
+
+We have an official message board where the community can chime in.
+* [Github Discussions for CHI-in-a-box Operators](https://github.com/ChameleonCloud/chi-in-a-box/discussions)
+* [Chameleon Helpdesk](https://chameleoncloud.org/user/help/ticket/new/)
+* [Chameleon user facing documentation](https://chameleoncloud.readthedocs.io/en/latest/contents.html)
+* [Upstream Kolla-Ansible documentation](https://docs.openstack.org/kolla-ansible/train/)
+
+
+## What should I know in order to get started?
+
+CHI-in-a-box is a packaging of Openstack, using heavy customization and templating via Ansible.
+At a minimum, you should be familiar with the Linux commandline, and some basics of system administration. Knowledge of the general architecture of OpenStack will make your life much easier.
+
+## How can I Contibute?
+
+### Reporting Bugs
+
+### Suggesting Enhancements
+
+### Local Development
+
+### Pull Requests
+
+### Issues and Pull Request Labels

--- a/README.md
+++ b/README.md
@@ -49,4 +49,4 @@ We hope the above list continues to shrink ;)
 
 ## Getting started
 
-Please refer to the repo [Wiki](https://github.com/ChameleonCloud/ansible-playbooks/wiki) for detailed information on what CHI-in-a-Box is, how it might enable science at your institution, how it works, and how to get started.
+Please refer to the repo [Wiki](https://github.com/ChameleonCloud/chi-in-a-box/wiki) for detailed information on what CHI-in-a-Box is, how it might enable science at your institution, how it works, and how to get started.


### PR DESCRIPTION
We should have contribution guidelines in chi-in-a-box. The impetus comes from qualifying for the open source gitbooks plan, however we don't currently have a good way for the community to contribute patches and bugfixes.

My hope was to end up with a template thats generally useful across our repos, as well as more specific info for chi-in-a-box and associate sites.