### PR TITLE
Add default resource property options

### DIFF
--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -60,7 +60,10 @@ blazar_database_user: blazar
 blazar_database_port: "{{ database_port }}"
 blazar_email_relay: "127.0.0.1"
 blazar_api_allocation_extras: user_name
+blazar_host_enable_default_resources: no
 blazar_host_default_resource_properties: '["=", "\$node_type", "compute_skylake"]'
+blazar_network_enable_default_resources: no
+blazar_network_retry_without_default_resources: no
 blazar_network_default_resource_properties: '["=", "\$stitch_provider", "none"]'
 
 # Cinder

--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -60,11 +60,10 @@ blazar_database_user: blazar
 blazar_database_port: "{{ database_port }}"
 blazar_email_relay: "127.0.0.1"
 blazar_api_allocation_extras: user_name
-blazar_host_enable_default_resources: no
 blazar_host_default_resource_properties: '["=", "\$node_type", "compute_skylake"]'
-blazar_network_enable_default_resources: no
-blazar_network_retry_without_default_resources: no
+blazar_host_retry_without_default_resources: yes
 blazar_network_default_resource_properties: '["=", "\$stitch_provider", "none"]'
+blazar_network_retry_without_default_resources: no
 
 # Cinder
 enable_cinder: no

--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -60,6 +60,8 @@ blazar_database_user: blazar
 blazar_database_port: "{{ database_port }}"
 blazar_email_relay: "127.0.0.1"
 blazar_api_allocation_extras: user_name
+blazar_host_default_resource_properties: '["=", "\$node_type", "compute_skylake"]'
+blazar_network_default_resource_properties: '["=", "\$stitch_provider", "none"]'
 
 # Cinder
 enable_cinder: no

--- a/kolla/node_custom_config/blazar.conf
+++ b/kolla/node_custom_config/blazar.conf
@@ -43,9 +43,8 @@ driver = messagingv2
 before_end = email
 email_relay = {{ blazar_email_relay }}
 enable_polling_monitor = true
-{% if blazar_host_enable_default_resources %}
+retry_allocation_without_defaults = {{ blazar_host_retry_without_default_resources | bool }}
 default_resource_properties = {{ blazar_host_default_resource_properties }}
-{% endif %}
 {% endif %}
 
 {% if enable_zun | bool %}
@@ -58,9 +57,7 @@ billrate = {{ blazar_floatingip_billrate }}
 
 [network]
 retry_allocation_without_defaults = {{ blazar_network_retry_without_default_resources | bool }}
-{% if blazar_network_enable_default_resources | bool %}
 default_resource_properties = {{ blazar_network_default_resource_properties }}
-{% endif %}
 
 [api]
 allocation_extras = {{ blazar_api_allocation_extras }}

--- a/kolla/node_custom_config/blazar.conf
+++ b/kolla/node_custom_config/blazar.conf
@@ -43,7 +43,9 @@ driver = messagingv2
 before_end = email
 email_relay = {{ blazar_email_relay }}
 enable_polling_monitor = true
+{% if blazar_host_enable_default_resources %}
 default_resource_properties = {{ blazar_host_default_resource_properties }}
+{% endif %}
 {% endif %}
 
 {% if enable_zun | bool %}
@@ -55,7 +57,10 @@ enable_polling_monitor = true
 billrate = {{ blazar_floatingip_billrate }}
 
 [network]
+retry_allocation_without_defaults = {{ blazar_network_retry_without_default_resources | bool }}
+{% if blazar_network_enable_default_resources | bool %}
 default_resource_properties = {{ blazar_network_default_resource_properties }}
+{% endif %}
 
 [api]
 allocation_extras = {{ blazar_api_allocation_extras }}

--- a/kolla/node_custom_config/blazar.conf
+++ b/kolla/node_custom_config/blazar.conf
@@ -43,6 +43,7 @@ driver = messagingv2
 before_end = email
 email_relay = {{ blazar_email_relay }}
 enable_polling_monitor = true
+default_resource_properties = {{ blazar_host_default_resource_properties }}
 {% endif %}
 
 {% if enable_zun | bool %}
@@ -52,6 +53,9 @@ enable_polling_monitor = true
 
 [virtual:floatingip]
 billrate = {{ blazar_floatingip_billrate }}
+
+[network]
+default_resource_properties = {{ blazar_network_default_resource_properties }}
 
 [api]
 allocation_extras = {{ blazar_api_allocation_extras }}


### PR DESCRIPTION
We may want to consider setting `retry_allocation_without_defaults = False` for network reservations, if we don't want users to get stitched networks when all of the other ones are reserved. 