### PR TITLE
enable floating IP reservations by default

### DIFF
--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -67,6 +67,7 @@ blazar_host_default_resource_properties: '["=", "\$node_type", "compute_skylake"
 blazar_host_retry_without_default_resources: yes
 blazar_network_default_resource_properties: '["=", "\$stitch_provider", "none"]'
 blazar_network_retry_without_default_resources: no
+blazar_floatingip_reservation_network_regex: "[pP]ublic"
 
 # Cinder
 enable_cinder: no

--- a/site-config.example/defaults.yml
+++ b/site-config.example/defaults.yml
@@ -69,5 +69,5 @@ kolla_external_fqdn: chi.example.com
 
 # If you are allowing users to reserve public IPs,
 # this should correspond to the Neutron ID of your
-# public (gateway) network.
-#blazar_floatingip_reservation_network_id: 687976bc-e93f-4c47-ac21-fbd341313a54
+# public (gateway) network. It defaults to allowing public/Public
+# blazar_floatingip_reservation_network_regex: "[pP]ublic"


### PR DESCRIPTION
allow reservation of floating IPs on network named "public" by default.