### PR TITLE
Add blazar_host_url_format in horizon config

### DIFF
--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -68,6 +68,7 @@ blazar_host_retry_without_default_resources: yes
 blazar_network_default_resource_properties: '["=", "\$stitch_provider", "none"]'
 blazar_network_retry_without_default_resources: no
 blazar_floatingip_reservation_network_regex: "[pP]ublic"
+blazar_host_url_format: "https://chameleoncloud.org/hardware/node/sites/{{ chameleon_site_name }}/clusters/chameleon/nodes/{hypervisor_hostname}/"
 
 # Cinder
 enable_cinder: no

--- a/kolla/node_custom_config/horizon/custom_local_settings
+++ b/kolla/node_custom_config/horizon/custom_local_settings
@@ -81,9 +81,7 @@ OPENSTACK_BLAZAR_DEVICE_RESERVATION = {
 }
 OPENSTACK_BLAZAR_HOST_RESERVATION = {
   'enabled': {{ enable_nova | bool }},
-{% if blazar_host_url_format is defined %}
   'url_format': '{{ blazar_host_url_format }}',
-{% endif %}
 }
 # Used for Blazar dashboard, which needs to pull data from the MySQL database
 # directly at the moment.

--- a/kolla/node_custom_config/horizon/custom_local_settings
+++ b/kolla/node_custom_config/horizon/custom_local_settings
@@ -82,7 +82,7 @@ OPENSTACK_BLAZAR_DEVICE_RESERVATION = {
 OPENSTACK_BLAZAR_HOST_RESERVATION = {
   'enabled': {{ enable_nova | bool }},
 {% if blazar_host_url_format is defined %}
-  'url_format': '{{ blazar_host_url_format }}}',
+  'url_format': '{{ blazar_host_url_format }}',
 {% endif %}
 }
 # Used for Blazar dashboard, which needs to pull data from the MySQL database

--- a/kolla/node_custom_config/horizon/custom_local_settings
+++ b/kolla/node_custom_config/horizon/custom_local_settings
@@ -81,6 +81,9 @@ OPENSTACK_BLAZAR_DEVICE_RESERVATION = {
 }
 OPENSTACK_BLAZAR_HOST_RESERVATION = {
   'enabled': {{ enable_nova }},
+{% if blazar_host_url_format is defined %}
+  'url_format': '{{ blazar_host_url_format }}}',
+{% endif %}
 }
 # Used for Blazar dashboard, which needs to pull data from the MySQL database
 # directly at the moment.


### PR DESCRIPTION
This is to link the blazar calendar rows to the hardware page.