### PR TITLE
template key_file location if not manually set

### DIFF
--- a/kolla/node_custom_config/neutron/ml2_conf.ini
+++ b/kolla/node_custom_config/neutron/ml2_conf.ini
@@ -66,9 +66,14 @@ token = {{ switch.auth.token }}
 {% else %}
 ip = {{ switch.address }}
 username = {{ switch.auth.username }}
+{% if switch.auth.password is defined %}
 password = {{ switch.auth.password }}
+{% endif %}
 {% if switch.auth.secret is defined %}
 secret = {{ switch.auth.secret }}
+{% endif %}
+{% if (switch.auth.private_key is defined) and (switch.ngs_config.key_file is not defined) %}
+key_file = /etc/neutron/ssh/id_{{ switch.name }}
 {% endif %}
 {% endif %}
 {% for key, value in (switch.ngs_config | default({})).items() %}


### PR DESCRIPTION
Populate ML2 conf with ssh key information, if set.
Password is now optional if key is used.