### PR TITLE
try copying admin-openrc out

### DIFF
--- a/cc-ansible
+++ b/cc-ansible
@@ -326,6 +326,7 @@ TRAPS+=(_lock_cleanup)
 # Prepare the configuration directory for the Kolla-Ansible invocation:
 CONFIG_DIR="$(mktemp -d)"
 _config_dir_cleanup() {
+  cp -n -v "$CONFIG_DIR/admin-openrc.sh" "$CC_ANSIBLE_SITE/admin-openrc.sh"
   rm -rf "$CONFIG_DIR"
 }
 TRAPS+=(_config_dir_cleanup)


### PR DESCRIPTION
due to our use of a tmpfs, we do not copy the adminrc into the site-config directory

in addition, due to how merging of defaults is working, the adminrc contains default kolla values, not our chi-in-a-box defaults.