### PR TITLE
Add openstackclient tools to venv

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,8 @@ lxml
 openstacksdk
 # See https://github.com/weldr/lorax/commit/c56d57ef7ee1c329161158ea8867064f74c0cffa
 future
+
+# Client Tools
+python-openstackclient
+python-doniclient
+python-ironicclient


### PR DESCRIPTION
Add openstackclient to the venv installation. A common question is how to install/run the tools, and this is sufficient given that the admin-openrc is present.
Installing climeleon seems overkill here.