### PR TITLE
fix admin-openrc to use site_config_dir

### DIFF
--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -13,7 +13,7 @@ kolla_install_type: source
 openstack_tag_suffix: ""
 
 # Write admin openRC to the site configuration
-admin_openrc_directory: "{{ cc_ansible_site_dir }}"
+admin_openrc_directory: "{{ site_config_dir }}"
 
 # Set according to https://docs.openstack.org/kolla-ansible/latest/user/virtual-environments.html#target-hosts
 # virtualenv specifies the path to the kolla virtualenv, while ansible_python_interpreter must be set explicitly


### PR DESCRIPTION
Rather than setting another arg via cc-ansible,set the path for the
site-config directory in the defaults.yml. This makes debugging easier.

Then, use this value to set the path for the admin-openrcr, to ensure
it is placed outside the tmp dir.