### PR TITLE
Refactor usage of env vars and ansible vars in cc-ansible

### DIFF
--- a/cc-ansible
+++ b/cc-ansible
@@ -360,7 +360,6 @@ kolla_args+=(--passwords="$CONFIG_DIR/passwords.yml")
 kolla_args+=(--extra node_custom_config="$CONFIG_DIR/node_custom_config")
 kolla_args+=(--extra cc_ansible_site_dir="$CONFIG_DIR")
 kolla_args+=(--extra deployment_dir="$DIR")
-kolla_args+=(--extra site_config_dir="$CC_ANSIBLE_SITE")
 
 # We set ansible ansible_python_interpreter to the virtualenv inside site-config, and override here during bootstrap.
 # Overriding at the CLI here applies to all hosts, including the deploy host.

--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -12,8 +12,11 @@ kolla_install_type: source
 # Remove this if pulling CentOS8 containers
 openstack_tag_suffix: ""
 
-# Write admin openRC to the site configuration
-admin_openrc_directory: "{{ cc_ansible_site_dir }}"
+# Store the value of CC_ANSIBLE_SITE in a variable, it's used for both admin-openrc, as
+# well as usage reporting
+site_config_dir: "{{ lookup('env','CC_ANSIBLE_SITE') }}"
+# Write admin openRC outside of the tmp dir used for template merging
+admin_openrc_directory: "{{ site_config_dir }}"
 
 # Set according to https://docs.openstack.org/kolla-ansible/latest/user/virtual-environments.html#target-hosts
 # virtualenv specifies the path to the kolla virtualenv, while ansible_python_interpreter must be set explicitly


### PR DESCRIPTION
We have significant duplication in how we set variables, and this leads to confusion and bugs. Primarily this is used to pass configuration directories as ansible vars.

This will match the current method used by the kolla-ansible bash script, as it sets the following env vars.

```
GLOBALS_DIR="${CONFIG_DIR}/globals.d"
EXTRA_GLOBALS=$(find ${GLOBALS_DIR} -maxdepth 1 -type f -name '*.yml' -printf ' -e @%p' 2>/dev/null)
GLOBALS_FILE="${GLOBALS_FILE:-${CONFIG_DIR}/globals.yml}"
PASSWORDS_FILE="${PASSWORDS_FILE:-${CONFIG_DIR}/passwords.yml}"
CONFIG_OPTS="-e @${GLOBALS_FILE} ${EXTRA_GLOBALS} -e @${PASSWORDS_FILE} -e CONFIG_DIR=${CONFIG_DIR}"
CMD="ansible-playbook $CONFIG_OPTS $EXTRA_OPTS $PLAYBOOK $VERBOSITY"
for INVENTORY in ${INVENTORIES[@]}; do
    CMD="${CMD} --inventory $INVENTORY"
done
```

The current list is as follows:

- path to chi-in-a-box checkout
  - `$DIR`, set by `"$(dirname "${BASH_SOURCE[0]}")"`
  - `cc_ansible_site_dir`
- path to venv created by cc-ansible
  - `$VIRTUALENV`
- path to site-config checkout
  - `$CC_ANSIBLE_SITE`
- path to tmpdir with templated site-config
  - `$CONFIG_DIR`
  - `cc_ansible_site_dir`

