### PR TITLE
Fix vendordata post-deploy roles

### DIFF
--- a/playbooks/vendordata.yml
+++ b/playbooks/vendordata.yml
@@ -1,7 +1,5 @@
 ---
 - hosts: vendordata
   roles: [vendordata]
-  become: true
-  become_user: root
   tags:
     - vendordata

--- a/roles/vendordata/tasks/main.yml
+++ b/roles/vendordata/tasks/main.yml
@@ -25,6 +25,26 @@
   run_once: True
   delegate_to: "{{ groups['control'][0] }}"
 
+
+- name: download vendordata container
+  block:
+    - name: login to chameleon docker registry
+      community.docker.docker_login:
+        registry_url: "{{ docker_registry }}"
+        username: "{{ docker_registry_username }}"
+        password: "{{ docker_registry_password }}"
+    - name: Pull Docker image
+      community.general.docker_image:
+        source: pull
+        name: "{{ vendordata_services.vendordata_api.image }}"
+        force_source: yes
+    - name: Log out of chameleon docker registry
+      community.docker.docker_login:
+        registry_url: "{{ docker_registry }}"
+        state: absent
+  when:
+  - inventory_hostname in groups["vendordata"]
+
 - name: Configure vendordata services.
   include_role:
     name: chameleon.docker_service


### PR DESCRIPTION
This fixes two issues.
1. the syntax to become a specific user is no longer valid, but is
   not needed, as the role uses become where necessary
2. Ensure the docker image is downloaded. The controller node may not be
   logged into the chameleon docker registry, in which case the systemd
   unit will fail to download the iamge or start.