### PR TITLE
Fix Post-Deploy

### DIFF
--- a/cc-ansible
+++ b/cc-ansible
@@ -364,9 +364,15 @@ if [[ "${POSARGS[*]}" =~ bootstrap-servers ]]; then
 fi
 
 if [[ "${POSARGS[*]}" =~ post-deploy ]]; then
+  post_deploy_play="$ansible_path/ciab_post_deploy.yml"
+  _post_override_cleanup() {
+    rm -f "$post_deploy_play"
+  }
+  TRAPS+=(_post_override_cleanup)
+
   # Important that the destination does not having a trailing `/`
-  cp -r "$DIR/playbooks/" "$ansible_path/chi"
-  kolla_args+=(--extra post_deploy_extra_play="chi/post_deploy.yml")
+  cp -f "$DIR/playbooks/post_deploy.yml" "$post_deploy_play"
+  kolla_args+=(--extra post_deploy_extra_play="ciab_post_deploy.yml")
 fi
 kolla_args+=("${POSARGS[@]}")
 

--- a/playbooks/post_deploy.yml
+++ b/playbooks/post_deploy.yml
@@ -2,26 +2,36 @@
 - hosts: control
   roles:
     - role: post_networking
-    - role: post_kvm
-      when: enable_kvm
     - role: post_ironic
       when: enable_ironic
 
-# Run other critical site playbooks
-- name: Set up vendordata metadata for instances (critical)
-  import_playbook: vendordata.yml
+- hosts: vendordata
+  roles: [vendordata]
 
-- name: Set up Hammers (periodic fix-it tasks)
-  import_playbook: hammers.yml
+- hosts: hammers
+  roles: [hammers]
 
-- name: Set up Chameleon image download tools
-  import_playbook: chameleon_image_tools.yml
+- hosts: chameleon-image-tools
+  roles: [chameleon_image_tools]
 
-- name: Set up mariadb automatic backups
-  import_playbook: backups.yml
+- hosts: deployment
+  roles:
+    - role: chameleon_mariadb
+      when: hostvars[groups['mariadb'][0]]['enable_mariabackup'] | bool
+      vars:
+        action: "deployment"
+- hosts: mariadb
+  roles:
+    - role: chameleon_mariadb
+      vars:
+        action: "config"
+  tags: mariadb
 
-- name: Set up Chameleon usage reporting
-  import_playbook: chameleon_usage.yml
+- hosts: chameleon_usage
+  roles:
+    - role: chameleon_usage
+      when: enable_usage_reporting | bool
 
-- name: Set up Precis
-  import_playbook: precis.yml
+- name: Install and configure services for Precis
+  hosts: precis
+  roles: [precis]

--- a/roles/post_ironic/tasks/networks.yml
+++ b/roles/post_ironic/tasks/networks.yml
@@ -10,10 +10,10 @@
     ironic_provisioning_network_vlan is defined
 
 - name: create interface for ironic gateway
-  michaelrigart.interfaces:
-    interfaces_ether_interfaces: >
-      {{ (ironic_interfaces | default([])) }}
-  become: True
+  include_role:
+    name: michaelrigart.interfaces
+  vars:
+    interfaces_ether_interfaces: "{{ (ironic_interfaces | default([])) }}"
   when:
     - manage_ironic_gateway_interface | bool
     - enable_ironic | bool

--- a/roles/post_networking/tasks/public.yml
+++ b/roles/post_networking/tasks/public.yml
@@ -3,17 +3,17 @@
 # Public net configuration
 ##########################
 
-- name: Check public network configuration
-  assert:
-    that:
-      - public_network is not false
-      - public_network.cidr is defined
-      - public_network.gateway_ip is defined
-    fail_msg: |
-      No 'public' neutron_network is defined! At least one externally-facing
-      network should be defined, and it should be called 'public'.
-  when:
-    - public_network is defined
+# - name: Check public network configuration
+#   assert:
+#     that:
+#       - public_network is not false
+#       - public_network.cidr is defined
+#       - public_network.gateway_ip is defined
+#     fail_msg: |
+#       No 'public' neutron_network is defined! At least one externally-facing
+#       network should be defined, and it should be called 'public'.
+#   when:
+#     - public_network is defined
 
 - name: Create public network
   kolla_toolbox:
@@ -36,6 +36,7 @@
     public_allocation_pool_end: "{{ public_network.allocation_pools[0].end | default(public_network.cidr | ipaddr('last_usable') | ipmath(-1)) }}"
   when:
     - public_network.cidr is defined
+    - public_network is defined
 
 # NOTE(jason): the os_subnet module doesn't support multiple allocation pools
 # at the moment, so only one allocation pool can be automatically created.
@@ -57,4 +58,5 @@
   vars:
     network: "{{ public_network }}"
   when:
+    - public_network.cidr is defined
     - public_network is defined


### PR DESCRIPTION
This PR allows post-deploy to finish. It mostly does so by avoiding the use of "import_playbook", due to the complex handling of ansible paths in cc-ansible and kolla-ansible.

Other small fixes to roles are included.