### PR TITLE
ensure usage reporting role can run with reduced privileges

### DIFF
--- a/roles/chameleon_usage/tasks/main.yml
+++ b/roles/chameleon_usage/tasks/main.yml
@@ -1,5 +1,13 @@
 ---
+- name: Authenticate to Docker registry
+  become: True
+  docker_login:
+    registry_url: "{{ docker_registry }}"
+    username: "{{ docker_registry_username }}"
+    password: "{{ docker_registry_password }}"
+
 - name: Pull Docker image.
+  become: True
   docker_image:
     source: pull
     name: "{{ chameleon_usage_docker_image }}"
@@ -27,6 +35,7 @@
     dest: "{{ chameleon_usage_config_dir }}/site.yaml"
 
 - name: Create MySQL user
+  become: true
   kolla_toolbox:
     module_name: mysql_user
     module_args:

--- a/roles/chameleon_usage/tasks/main.yml
+++ b/roles/chameleon_usage/tasks/main.yml
@@ -64,6 +64,7 @@
       - 'nova.*:SELECT'
 
 - name: Initialize chameleon_usage database
+  become: true
   command: |
     docker run --rm --net=host \
     -v "{{ chameleon_usage_config_dir }}/my.cnf:/etc/mysql/my.cnf" \


### PR DESCRIPTION
Kolla_toolbox and docker roles need `become` if the user is not a member of the docker group.
We also need to authenticate to the registry.