### PR TITLE
[ironic] fix encryption of root password for debug login

### DIFF
--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -162,8 +162,9 @@ ironic_provisioning_network_cidr: 10.51.0.0/24
 ironic_provisioning_network_gateway: "{{ ironic_provisioning_network_cidr | ipaddr('next_usable') }}"
 ironic_cleaning_network: "{{ ironic_provisioning_network }}"
 ironic_image_cache_size: 20480 # MB
+ironic_console_serial_speed: 115200n8
 encoded_ironic_pxe_root_password: "{{ ironic_pxe_root_password | password_hash('md5') |  regex_replace( '(\\$)', '$\\1') }}"
-ironic_pxe_append_params: nofb nomodeset vga=normal console=tty0 console=ttyS0,9600 systemd.journald.forward_to_console=yes rootpwd="{{ encoded_ironic_pxe_root_password }}"
+ironic_pxe_append_params: nofb nomodeset vga=normal console=tty0 console=ttyS0,{{ ironic_console_serial_speed }} systemd.journald.forward_to_console=yes rootpwd="{{ encoded_ironic_pxe_root_password }}"
 
 # Defaults for inspection network, currently unused
 ironic_dnsmasq_dhcp_range: "10.52.0.10,10.52.0.200,255.255.255.0"

--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -162,7 +162,8 @@ ironic_provisioning_network_cidr: 10.51.0.0/24
 ironic_provisioning_network_gateway: "{{ ironic_provisioning_network_cidr | ipaddr('next_usable') }}"
 ironic_cleaning_network: "{{ ironic_provisioning_network }}"
 ironic_image_cache_size: 20480 # MB
-ironic_pxe_append_params: "nofb nomodeset vga=normal console=tty0 console=ttyS0,9600 systemd.journald.forward_to_console=yes rootpwd={{ ironic_pxe_root_password }}"
+encoded_ironic_pxe_root_password: "{{ ironic_pxe_root_password | password_hash('md5') |  regex_replace( '(\\$)', '$\\1') }}"
+ironic_pxe_append_params: nofb nomodeset vga=normal console=tty0 console=ttyS0,9600 systemd.journald.forward_to_console=yes rootpwd="{{ encoded_ironic_pxe_root_password }}"
 
 # Defaults for inspection network, currently unused
 ironic_dnsmasq_dhcp_range: "10.52.0.10,10.52.0.200,255.255.255.0"

--- a/kolla/node_custom_config/ironic.conf
+++ b/kolla/node_custom_config/ironic.conf
@@ -41,7 +41,7 @@ timeout = 900
 driver = messagingv2
 
 [pxe]
-kernel_append_params = "{{ ironic_pxe_append_params }}"
+pxe_append_params = "{{ ironic_pxe_append_params }}"
 image_cache_size = "{{ ironic_image_cache_size }}"
 # [ech] Still needed for ARM? pxe_bootfile_name_by_arch = aarch64:shimaa64.efi
 


### PR DESCRIPTION
this fixes the encoding of the root password to pass through both yaml syntax, ansible's templating, and the escaping needed by the linux kernel commandline.

The second commit bumps the serial console speed from 9600 to 115200, greatly speeding up boot and the debugging process.