### PR TITLE
Make ironic backoff on neutron api failures

### DIFF
--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -166,6 +166,11 @@ ironic_console_serial_speed: 115200n8
 encoded_ironic_pxe_root_password: "{{ ironic_pxe_root_password | password_hash('md5') |  regex_replace( '(\\$)', '$\\1') }}"
 ironic_pxe_append_params: nofb nomodeset vga=normal console=tty0 console=ttyS0,{{ ironic_console_serial_speed }} systemd.journald.forward_to_console=yes rootpwd="{{ encoded_ironic_pxe_root_password }}"
 
+# number of times to retry failed neutron api requests
+# will use exponential backoff from 0.5s up to 60s, or
+# will use ironic_neutron_status_code_retry_delay if set
+ironic_neutron_status_code_retries: 10
+
 # Defaults for inspection network, currently unused
 ironic_dnsmasq_dhcp_range: "10.52.0.10,10.52.0.200,255.255.255.0"
 

--- a/kolla/node_custom_config/ironic.conf
+++ b/kolla/node_custom_config/ironic.conf
@@ -34,7 +34,13 @@ default_boot_option = local
 [neutron]
 cleaning_network = "{{ ironic_cleaning_network }}"
 provisioning_network = "{{ ironic_provisioning_network }}"
-timeout = 900
+
+{% if ironic_neutron_status_code_retries is defined %}
+status_code_retries = "{{ ironic_neutron_status_code_retries }}"
+{% endif %}
+{% if ironic_neutron_status_code_retry_delay is defined %}
+status_code_retry_delay = "{{ ironic_neutron_status_code_retry_delay }}"
+{% endif %}
 
 [oslo_messaging_notifications]
 # Experiment Precis requires 2.0 message format, i.e. set driver to messagingv2


### PR DESCRIPTION
When networking-generic-switch is used as the ML2 driver for Neutron,
configuring ports may take a very long time. Increasing the API request
timeout does not resolve this, as neutron's queue may grow without bound.

Instead, we have ironic keep a short timeout, and retry on failures,
with exponential backoff. This allows neutron to apply backpressure to
ironic when the queue grows too long.

See https://docs.openstack.org/ironic/xena/configuration/config.html#neutron.status_code_retries

Two configuration parameters are added:

* `ironic_neutron_status_code_retries`
  For requests failing with a "retriable" status code, ironic will retry
  the request this many times.
* `ironic_neutron_status_code_retry_delay`
  Specifies the delay between retries, in seconds.
  If not set, retries will use exponential backoff, starting at 0.5s,
  and increasing up to 60s.
  Only set this value if neutron requests often take 60s or more, in
  which case the exponential backoff's maximum will be insufficient to
  allow the queue to drain.