### PR TITLE
only set default pxe images if defined

### DIFF
--- a/kolla/node_custom_config/ironic.conf
+++ b/kolla/node_custom_config/ironic.conf
@@ -25,8 +25,12 @@ port_range = 40000:50000
 automated_clean = False
 
 # deploy kernel and ramdisk to use if not set on node
-deploy_kernel = "{{ ironic_deploy_kernel | default('pxe_deploy_kernel') }}"
-deploy_ramdisk = "{{ ironic_deploy_ramdisk | default('pxe_deploy_ramdisk') }}"
+{% if ironic_deploy_kernel is defined %}
+deploy_kernel = "{{ ironic_deploy_kernel }}"
+{% endif %}
+{% if ironic_deploy_ramdisk is defined %}
+deploy_ramdisk = "{{ ironic_deploy_ramdisk }}"
+{% endif %}
 
 [deploy]
 default_boot_option = local


### PR DESCRIPTION
Only set the values of `deploy_kernel` and `deploy_ramdisk` if a UUID is defined. Setting a string as default value causes misleading error messages, it's better to leave it unset.


Nodes without deploy_kernel or deploy_ramdisk set in their properties will use this site-wide default.