### PR TITLE
host-endpoint: deny traffic to private ips by default

### DIFF
--- a/docs/reference/resource-reservation/README.md
+++ b/docs/reference/resource-reservation/README.md
@@ -27,13 +27,17 @@ openstack reservation host create
 
 ### Devices
 
+```
+openstack reservation device create
+```
+
 ### Networks
 
 #### Create a Reservable Network
 
 This creates an entry in Blazar, allowing a user to reserve a vlan on a physical network. When their lease starts, a neutron network will be created using that vlan and physnet.
 
-Make sure that the segment ID + physnets you add here are **outside** the range of ad-hoc vlans defined for neutron (in your defaults.yml file). Otherwise, blazar's reservable vlans and neutron's ad-hoc ones may conflict.\
+Make sure that the segment ID + physnets you add here are **outside** the range of ad-hoc vlans defined for neutron (in your `defaults.yml` file). Otherwise, Blazar's reservable vlans and neutron's ad-hoc ones may conflict.\
 
 
 Usage:
@@ -64,10 +68,26 @@ openstack reservation network create \
   --extra mykey=myvalue
 ```
 
-#### Add a capability to a Reservable Network
+#### Add or update capability to a Reservable Network
 
 ```shell-session
 openstack reservation network set --extra key=value NETWORK_ID
+```
+
+Example, change the physical network:
+
+```
+openstack reservation network set --extra physical_network=physnet1
+```
+
+#### Convention for Stitch-able Networks
+
+To indicate that a network can be connected to other sites at L2, we use the key `stitch_provider`
+
+For example, if you have plumbed VLANs from your dataplane switch to a FABRIC facility port, indicate these with:
+
+```
+openstack reservation network set --extra stitch_provider=fabric
 ```
 
 ### Floating IPs

--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -108,6 +108,7 @@ enable_haproxy: yes
 haproxy_listen_neutron_server_extra: ["timeout server 15m"]
 haproxy_service_template: "haproxy_single_service_split.cfg.j2"
 kolla_external_fqdn_cert: "{{ cc_ansible_site_dir }}/certificates/haproxy.pem"
+kolla_externally_managed_cert: "{{ enable_letsencrypt | bool }}"
 
 # Heat
 enable_heat: yes

--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -168,6 +168,10 @@ ironic_console_serial_speed: 115200n8
 encoded_ironic_pxe_root_password: "{{ ironic_pxe_root_password | password_hash('md5') |  regex_replace( '(\\$)', '$\\1') }}"
 ironic_pxe_append_params: nofb nomodeset vga=normal console=tty0 console=ttyS0,{{ ironic_console_serial_speed }} systemd.journald.forward_to_console=yes rootpwd="{{ encoded_ironic_pxe_root_password }}"
 
+# This can be "expensive"; allow setting it explicitly, but default to the prometheus interval
+ironic_send_sensor_data_interval: 60
+ironic_send_sensor_data_for_undeployed_nodes: False
+
 # number of times to retry failed neutron api requests
 # will use exponential backoff from 0.5s up to 60s, or
 # will use ironic_neutron_status_code_retry_delay if set
@@ -279,6 +283,8 @@ prometheus_openstack_exporter_cmdline_extras: >-
 prometheus_server_external_url: "{{ public_protocol }}://{{ prometheus_external_fqdn }}:{{ prometheus_port }}"
 prometheus_alertmanager_external_url: "{{ public_protocol }}://{{ prometheus_external_fqdn }}:{{ prometheus_alertmanager_port }}"
 prometheus_bind_address: "{{ lookup('vars', 'ansible_' + network_interface).ipv4.address }}"
+
+enable_prometheus_ironic_exporter: "{{ enable_prometheus | bool and enable_ironic | bool }}"
 
 # Redfish Monitor
 redfish_monitor_openstack_user: "{{ keystone_admin_username }}"

--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -72,6 +72,7 @@ blazar_email_relay: "127.0.0.1"
 blazar_api_allocation_extras: user_name
 blazar_host_default_resource_properties: '["=", "\$node_type", "compute_skylake"]'
 blazar_host_retry_without_default_resources: yes
+blazar_enable_plugin_network: yes
 blazar_network_default_resource_properties: '["=", "\$stitch_provider", "none"]'
 blazar_network_retry_without_default_resources: no
 blazar_floatingip_reservation_network_regex: "[pP]ublic"
@@ -310,9 +311,14 @@ enable_grafana: no
 enable_ceph: no
 
 # Container services (Zun and supporting)
-enable_etcd: no
-enable_kuryr: no
+enable_k3s: no
 enable_zun: no
+enable_zun_compute_k8s: "{{ enable_zun | bool and enable_k3s | bool }}"
+blazar_enable_device_plugin_k8s: "{{ enable_k3s | bool }}"
+# If not running K3s, can run standard Zun deploy w/ etcd and kuryr
+enable_etcd: "{{ enable_zun | bool and not enable_k3s | bool }}"
+enable_kuryr: "{{ enable_zun | bool and not enable_k3s | bool }}"
+enable_zun_compute: "{{ enable_zun | bool and not enable_k3s | bool }}"
 
 # OSG
 enable_osg: no

--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -284,7 +284,7 @@ prometheus_server_external_url: "{{ public_protocol }}://{{ prometheus_external_
 prometheus_alertmanager_external_url: "{{ public_protocol }}://{{ prometheus_external_fqdn }}:{{ prometheus_alertmanager_port }}"
 prometheus_bind_address: "{{ lookup('vars', 'ansible_' + network_interface).ipv4.address }}"
 
-enable_prometheus_ironic_exporter: "{{ enable_prometheus | bool and enable_ironic | bool }}"
+enable_prometheus_ironic_exporter: no
 
 # Redfish Monitor
 redfish_monitor_openstack_user: "{{ keystone_admin_username }}"

--- a/kolla/node_custom_config/doni.conf
+++ b/kolla/node_custom_config/doni.conf
@@ -1,5 +1,23 @@
 [DEFAULT]
-enabled_worker_types = ironic{% if enable_blazar | bool %},blazar.physical_host{% endif %}
+{% set hardware_types_list = [] %}
+{% set worker_types_list = [] %}
+{% if enable_ironic | bool %}
+    {{ worker_types_list.append("ironic")}}
+    {{ hardware_types_list.append("baremetal")}}
+    {% if enable_blazar | bool %}{{ worker_types_list.append("blazar.physical_host")}}{%endif%}
+{%endif%}
+
+{% if enable_k3s | bool %}
+    {{ worker_types_list.append("balena")}}
+    {{ worker_types_list.append("k8s")}}
+    {{ hardware_types_list.append("device.balena")}}
+    {% if enable_blazar | bool %}{{ worker_types_list.append("blazar.device")}}{%endif%}
+{%endif%}
+
+{% if enable_tunelo | bool %} {{ worker_types_list.append("tunelo")}} {%endif%}
+
+enabled_hardware_types = {{ hardware_types_list|join(',') }}
+enabled_worker_types = {{ worker_types_list|join(',') }}
 
 [worker]
 {% if enable_blazar | bool %}
@@ -9,4 +27,19 @@ enabled_worker_types = ironic{% if enable_blazar | bool %},blazar.physical_host{
 # concurrency from 1000 to a much lower value, approaching more of a
 # single-threaded serial execution model.
 task_concurrency = 5
+{% endif %}
+
+{% if balena_api_token is defined %}
+[balena]
+api_token = {{ balena_api_token }}
+device_fleet_mapping = raspberrypi3-64:chi-edge-workers,raspberrypi4-64:chi-edge-workers,jetson-nano:chi-edge-workers,jetson-xavier-nx-emmc:chi-edge-workers
+{% endif %}
+
+{% if enable_k3s | bool %}
+[k8s]
+expected_labels_index_property = machine_name
+expected_labels = raspberrypi4-64:smarter-device-manager=enabled|smarter-device-manager/configmap=rpi,
+                  raspberrypi3-64:smarter-device-manager=enabled|smarter-device-manager/configmap=rpi,
+                  jetson-nano:smarter-device-manager=enabled|smarter-device-manager/configmap=jetson|nvidia-device-plugin/enabled=true,
+                  jetson-xavier-nx-emmc:smarter-device-manager=enabled|smarter-device-manager/configmap=jetson|nvidia-device-plugin/enabled=true
 {% endif %}

--- a/kolla/node_custom_config/ironic.conf
+++ b/kolla/node_custom_config/ironic.conf
@@ -23,8 +23,12 @@ port_range = 40000:50000
 [conductor]
 # We do not perform automated cleaning to improve turnaround time on a node.
 automated_clean = False
+
+{% if enable_prometheus_ironic_exporter | bool %}
+send_sensor_data = True
 send_sensor_data_interval = "{{ ironic_send_sensor_data_interval }}"
 send_sensor_data_for_undeployed_nodes = "{{ ironic_send_sensor_data_for_undeployed_nodes }}"
+{% endif %}
 
 # deploy kernel and ramdisk to use if not set on node
 {% if ironic_deploy_kernel is defined %}

--- a/kolla/node_custom_config/ironic.conf
+++ b/kolla/node_custom_config/ironic.conf
@@ -23,6 +23,8 @@ port_range = 40000:50000
 [conductor]
 # We do not perform automated cleaning to improve turnaround time on a node.
 automated_clean = False
+send_sensor_data_interval = "{{ ironic_send_sensor_data_interval }}"
+send_sensor_data_for_undeployed_nodes = "{{ ironic_send_sensor_data_for_undeployed_nodes }}"
 
 # deploy kernel and ramdisk to use if not set on node
 {% if ironic_deploy_kernel is defined %}
@@ -49,6 +51,12 @@ status_code_retry_delay = "{{ ironic_neutron_status_code_retry_delay }}"
 [oslo_messaging_notifications]
 # Experiment Precis requires 2.0 message format, i.e. set driver to messagingv2
 driver = messagingv2
+
+# driver is a list, but ini merging breaks that. Set it again here.
+{% if enable_prometheus_ironic_exporter | bool %}
+driver = prometheus_exporter
+location = /opt/stack/node_metrics
+{% endif %}
 
 [pxe]
 pxe_append_params = "{{ ironic_pxe_append_params }}"

--- a/kolla/node_custom_config/neutron/ml2_conf.ini
+++ b/kolla/node_custom_config/neutron/ml2_conf.ini
@@ -2,11 +2,10 @@
 mechanism_drivers = {% if enable_neutron_wireguard | bool %}wireguard,{% endif %}openvswitch,genericswitch,{% if enable_ironic_neutron_agent | bool %}baremetal,{% endif %}l2population
 
 [ml2_type_flat]
-{% if enable_ironic | bool %}
+# Allow creating flat networks against any physical provider network
+# (in practice this isn't always valid, but Kolla Ansible by default is opinionated
+# about what the provider networks should be named.)
 flat_networks = *
-{% else %}
-flat_networks = public
-{% endif %}
 
 [ml2_type_vlan]
 {# DEPRECATED: neutron_network_vlan_ranges still takes priority if in use #}

--- a/kolla/node_custom_config/zun.conf
+++ b/kolla/node_custom_config/zun.conf
@@ -7,15 +7,34 @@ minimum_disk = 0
 default_cpu = 0.0
 default_memory = 0
 default_disk = 0
+{% if enable_zun_compute_k8s | bool %}
+# We support containers, but not capsules when k8s driver is in use.
+container_driver = k8s
+capsule_driver = fake
+# Change from default of 60 seconds; for k8s this is a cheap operation and the UX
+# is better with a tighter sync interval.
+sync_container_state_interval = 15
+{% endif %}
 
 [compute]
 host_shared_with_nova = {% if enable_nova | bool %}true{% else %}false{% endif %}
 
 [scheduler]
 available_filters = zun.scheduler.filters.all_filters
-enabled_filters = {% if enable_blazar | bool %}BlazarFilter,{% endif %}RamFilter,CPUFilter,ComputeFilter,RuntimeFilter
+enabled_filters = {% if enable_blazar | bool %}BlazarFilter,{% endif %}ComputeFilter,RuntimeFilter
 
 {% if enable_blazar | bool %}
 [blazar:host]
 allow_without_reservation = False
+{% endif %}
+
+{% if enable_zun_compute_k8s | bool %}
+[k8s]
+{% if enable_neutron | bool %}
+neutron_network = caliconet
+{% endif %}
+device_profile_mappings = jetson_camera=smarter-devices/video0:1
+device_profile_mappings = pi_camera=smarter-devices/video0:1,smarter-devices/vchiq:1,smarter-devices/vcsm-cma:1
+device_profile_mappings = pi_gpio=smarter-devices/gpiomem:1
+device_profile_mappings = pi_serial=smarter-devices/ttyACM0:1
 {% endif %}

--- a/playbooks/k3s.yml
+++ b/playbooks/k3s.yml
@@ -1,0 +1,6 @@
+---
+- hosts: k3s
+  roles:
+    - name: install k3s controller
+      role: k3s
+      when: enable_k3s | bool

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
-ansible>=2.10,<=4
+# Xena release of Kolla-ansible requires ansible release between 2.10 and below 5.x,
+# This is because it depends on ansible-core 2.11.x
+# See https://docs.openstack.org/releasenotes/kolla-ansible/xena.html#relnotes-13-0-0-stable-xena-upgrade-notes
+ansible>=2.10,<5
 
 # ensure the version of pyopenssl installed is compatible with cryptography. May be resolved after ansible 5.x
 # https://github.com/pyca/pyopenssl/issues/1114

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,9 @@
 ansible>=2.10,<=4
+
+# ensure the version of pyopenssl installed is compatible with cryptography. May be resolved after ansible 5.x
+# https://github.com/pyca/pyopenssl/issues/1114
+pyopenssl
+
 # Jinja2 3.1 breaks filters, removes py3.6 support
 # See https://jinja.palletsprojects.com/en/3.1.x/changes/#version-3-1-0
 jinja2<3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ ansible>=2.10,<=4
 # See https://jinja.palletsprojects.com/en/3.1.x/changes/#version-3-1-0
 jinja2<3.1.0
 docker
+kubernetes
 
 # Client Tools
 python-openstackclient

--- a/roles/chameleon_mariadb/tasks/deployment.yml
+++ b/roles/chameleon_mariadb/tasks/deployment.yml
@@ -12,3 +12,5 @@
     task_name: "mariadb_backup_{{ mariadb_backup_timer_suffix }}"
     task_command: "{{ deployment_dir }}/cc-ansible --site {{ deployment_site_config_dir }} mariadb_backup"
     task_calendar: "23:00"
+    task_user: "{{ mariadb_backup_task_user|default(None) }}"
+    task_group: "{{ mariadb_backup_task_group|default(None) }}"

--- a/roles/k3s/defaults/main.yml
+++ b/roles/k3s/defaults/main.yml
@@ -1,0 +1,33 @@
+---
+k3s_version: v1.22.5+k3s1
+k3s_port: 6443
+k3s_server_location: /var/lib/rancher/k3s
+k3s_conf_location: /etc/rancher/k3s
+k3s_systemd_dir: /etc/systemd/system
+k3s_server_ip: "{{ kolla_external_vip_address }}"
+k3s_extra_server_args: ""
+
+k3s_dry_run: no
+
+k3s_cluster_cidr: "192.168.64.0/18"
+k3s_cluster_node_blocksize: 28
+
+k3s_enable_calico: yes
+k3s_calico_version: v3.24.1
+
+k3s_nvidia_device_plugin_version: "v0.12.2"
+k3s_smarter_device_plugin_version: "v1.20.10"
+
+k3s_enable_registry_proxy: no
+
+k3s_services:
+  k3s_server:
+    group: k3s
+    enabled: "{{ enable_k3s }}"
+    haproxy:
+      k3s_server_external:
+        enabled: true
+        external: true
+        mode: "http"
+        port: "{{ k3s_port }}"
+        listen_port: "{{ k3s_port }}"

--- a/roles/k3s/files/calico-global-networkpolicy-allow-ping.yaml
+++ b/roles/k3s/files/calico-global-networkpolicy-allow-ping.yaml
@@ -1,0 +1,19 @@
+# https://projectcalico.docs.tigera.io/security/icmp-ping#allow-icmp-ping-all-workloads-and-host-endpoints
+apiVersion: projectcalico.org/v3
+kind: GlobalNetworkPolicy
+metadata:
+  name: allow-ping
+spec:
+  namespaceSelector: has(kubernetes.io/metadata.name) && kubernetes.io/metadata.name not in {"kube-system", "calico-apiserver", "calico-system"}
+  types:
+    - Ingress
+  ingress:
+    # Allow ICMP echo (ping) over IPv4 and IPv6
+    - action: Allow
+      protocol: ICMP
+      icmp:
+        type: 8
+    - action: Allow
+      protocol: ICMPv6
+      icmp:
+        type: 128

--- a/roles/k3s/files/calico-global-networkpolicy-default-deny.yaml
+++ b/roles/k3s/files/calico-global-networkpolicy-default-deny.yaml
@@ -1,0 +1,18 @@
+# https://projectcalico.docs.tigera.io/security/kubernetes-default-deny#enable-default-deny-calico-global-network-policy-non-namespaced
+apiVersion: projectcalico.org/v3
+kind: GlobalNetworkPolicy
+metadata:
+  name: default-deny
+spec:
+  namespaceSelector: has(kubernetes.io/metadata.name) && kubernetes.io/metadata.name not in {"kube-system", "calico-apiserver", "calico-system"}
+  types:
+    - Ingress
+    - Egress
+  egress:
+    # allow all namespaces to communicate to DNS pods
+    - action: Allow
+      protocol: UDP
+      destination:
+        selector: 'k8s-app == "kube-dns"'
+        ports:
+          - 53

--- a/roles/k3s/files/calico-global-networkpolicy-host.yaml
+++ b/roles/k3s/files/calico-global-networkpolicy-host.yaml
@@ -1,0 +1,89 @@
+---
+# enable auto host-endpoints
+# https://projectcalico.docs.tigera.io/reference/resources/kubecontrollersconfig
+apiVersion: projectcalico.org/v3
+kind: KubeControllersConfiguration
+metadata:
+  name: default
+spec:
+  controllers:
+    node:
+      hostEndpoint:
+        autoCreate: Enabled
+      syncLabels: Enabled
+---
+# define failsafe ports for felix
+apiVersion: projectcalico.org/v3
+kind: FelixConfiguration
+metadata:
+  name: default
+spec:
+  failsafeInboundHostPorts:
+    - port: 22
+      protocol: tcp
+    - port: 68
+      protocol: udp
+    - port: 179
+      protocol: tcp
+    - port: 2379
+      protocol: tcp
+    - port: 2380
+      protocol: tcp
+    - port: 5473
+      protocol: tcp
+    - port: 6443
+      protocol: tcp
+    - port: 6666
+      protocol: tcp
+    - port: 6667
+      protocol: tcp
+  failsafeOutboundHostPorts:
+    - port: 53
+      protocol: udp
+    - port: 67
+      protocol: udp
+    - port: 179
+      protocol: tcp
+    - port: 2379
+      protocol: tcp
+    - port: 2380
+      protocol: tcp
+    - port: 5473
+      protocol: tcp
+    - port: 6443
+      protocol: tcp
+    - port: 6666
+      protocol: tcp
+    - port: 6667
+      protocol: tcp
+    - port: 9099
+      protocol: tcp
+    - port: 10010
+      protocol: tcp
+    - port: 10250
+      protocol: tcp
+---
+apiVersion: projectcalico.org/v3
+kind: GlobalNetworkPolicy
+metadata:
+  name: edge-host-worker
+spec:
+  selector: "chi.edge/local_egress == 'deny'"
+  applyOnForward: True # applies to all traffic through host interfaces
+  order: 100 #lowest priority, after other rules
+  types:
+    - Egress
+  egress:
+    # don't block traffic to known k8s pods,hosts,etc
+    - action: Allow
+      destination:
+        selector: all() #all endpoints known to k8s
+    # if traffic isn't going to a k8s endpoint, allow it
+    - action: Deny
+      destination:
+        nets:
+          - 10.0.0.0/8
+          - 172.16.0.0/12
+          - 192.168.0.0/16
+    # allow egress traffic not matched above
+    - action: Allow

--- a/roles/k3s/files/debug-pingtest.yaml
+++ b/roles/k3s/files/debug-pingtest.yaml
@@ -1,0 +1,39 @@
+# Launch a pod on every node in the cluster with the debug=pingtest label
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: pingtest
+spec:
+  selector:
+    matchLabels:
+      name: pingtest
+  template:
+    metadata:
+      labels:
+        name: pingtest
+    spec:
+      nodeSelector:
+        debug: pingtest
+      containers:
+        - name: pingtest
+          image: busybox
+          command: ["sleep", "infinity"]
+
+---
+# Network policy to allow traffic b/w pods on same namespace
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-allow-local
+spec:
+  podSelector: {}
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: default
+  egress:
+    - {}
+  policyTypes:
+    - Ingress
+    - Egress

--- a/roles/k3s/files/debug-shell.yaml
+++ b/roles/k3s/files/debug-shell.yaml
@@ -1,0 +1,20 @@
+# This spec just creates a simple pod that doesn't do much,
+# so you can test if shell access works via kubectl.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: shell-demo
+spec:
+  volumes:
+    - name: shared-data
+      emptyDir: {}
+  containers:
+    - name: nginx
+      image: nginx
+      volumeMounts:
+        - name: shared-data
+          mountPath: /usr/share/nginx/html
+  dnsPolicy: Default
+  # To target to specific host:
+  # nodeSelector:
+  #   kubernetes.io/hostname: <hostname>

--- a/roles/k3s/files/nvidia-device-plugin.yaml
+++ b/roles/k3s/files/nvidia-device-plugin.yaml
@@ -1,0 +1,64 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nvidia-device-plugin-daemonset
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      name: nvidia-device-plugin-ds
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      # This annotation is deprecated. Kept here for backward compatibility
+      # See https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+      labels:
+        name: nvidia-device-plugin-ds
+    spec:
+      nodeSelector:
+        "nvidia-device-plugin/enabled": "true"
+      tolerations:
+        # This toleration is deprecated. Kept here for backward compatibility
+        # See https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      # Mark this pod as a critical add-on; when enabled, the critical add-on
+      # scheduler reserves resources for critical add-on pods so that they can
+      # be rescheduled after a failure.
+      # See https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
+      priorityClassName: "system-node-critical"
+      containers:
+        - image: nvcr.io/nvidia/k8s-device-plugin:v0.12.2
+          name: nvidia-device-plugin-ctr
+          args: ["--fail-on-init-error=false"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: device-plugin
+              mountPath: /var/lib/kubelet/device-plugins
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins

--- a/roles/k3s/tasks/config-calico.yml
+++ b/roles/k3s/tasks/config-calico.yml
@@ -1,0 +1,64 @@
+---
+- name: ensure calico config directory exists
+  become: true
+  ansible.builtin.file:
+    name: "{{ k3s_conf_location }}/calico"
+    state: directory
+
+- name: Download Calico release
+  become: true
+  ansible.builtin.get_url:
+    url: "https://github.com/projectcalico/calico/releases/download/{{ k3s_calico_version }}/release-{{ k3s_calico_version }}.tgz"
+    dest: "{{ k3s_conf_location }}/calico/release-{{ k3s_calico_version }}.tgz"
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Unpack Calico release
+  become: true
+  ansible.builtin.unarchive:
+    remote_src: yes
+    src: "{{ k3s_conf_location }}/calico/release-{{ k3s_calico_version }}.tgz"
+    dest: "{{ k3s_conf_location }}/calico/"
+    creates: "{{ k3s_conf_location }}/calico/release-{{ k3s_calico_version }}"
+  register: calico_release
+
+# note: server-side-apply used due to the large size
+- name: Apply Calico operator
+  delegate_to: "{{ groups['deployment'][0] }}"
+  kubernetes.core.k8s:
+    state: present
+    src: "{{ k3s_conf_location }}/calico/release-{{ k3s_calico_version }}/manifests/tigera-operator.yaml"
+    apply: yes
+    server_side_apply:
+      field_manager: ansible
+      force_conflicts: yes
+  when:
+    - not (k3s_dry_run | bool)
+
+- name: Install calicoctl
+  become: true
+  ansible.builtin.copy:
+    # TODO: use facts to optionally install ARM or otherwise
+    src: "{{ k3s_conf_location }}/calico/release-{{ k3s_calico_version }}/bin/calicoctl/calicoctl-linux-amd64"
+    remote_src: yes
+    dest: /usr/local/bin/kubectl-calico
+    mode: u=rwx,g=rx,o=rx
+
+- name: Apply Calico custom resources
+  delegate_to: "{{ groups['deployment'][0] }}"
+  kubernetes.core.k8s:
+    state: present
+    template: calico-custom-resources.yaml.j2
+    apply: yes
+  when:
+    - not (k3s_dry_run | bool)
+
+- name: Apply Calico global network policies
+  delegate_to: "{{ groups['deployment'][0] }}"
+  kubernetes.core.k8s:
+    state: present
+    src: calico-global-networkpolicy-{{ item }}.yaml
+  loop:
+    - default-deny
+    - allow-ping

--- a/roles/k3s/tasks/config-device-plugins.yml
+++ b/roles/k3s/tasks/config-device-plugins.yml
@@ -1,0 +1,24 @@
+---
+# FUTURE NOTE: change all the kubectl invocations to use the kubernetes.core.k8s collection!
+# This will make detecting changes way easier and more reliable.
+
+- name: Apply nvidia device plugin daemonset
+  delegate_to: "{{ groups['deployment'][0] }}"
+  kubernetes.core.k8s:
+    state: present
+    src: nvidia-device-plugin.yaml
+    apply: yes
+  when:
+    - not (k3s_dry_run | bool)
+
+- name: Apply daemonsets for smarter-device plugins
+  delegate_to: "{{ groups['deployment'][0] }}"
+  kubernetes.core.k8s:
+    state: present
+    template: "smarter-device-manager-ds-{{ item }}.yaml.j2"
+    apply: yes
+  loop:
+    - jetson
+    - rpi
+  when:
+    - not (k3s_dry_run | bool)

--- a/roles/k3s/tasks/config-k3s-client.yml
+++ b/roles/k3s/tasks/config-k3s-client.yml
@@ -1,0 +1,82 @@
+---
+- name: Wait for node-token
+  become: true
+  ansible.builtin.wait_for:
+    path: "{{ k3s_server_location }}/server/node-token"
+
+- name: Register node-token file access mode
+  become: true
+  ansible.builtin.stat:
+    path: "{{ k3s_server_location }}/server/node-token"
+  register: p
+
+- name: Change file access node-token
+  become: true
+  ansible.builtin.file:
+    path: "{{ k3s_server_location }}/server/node-token"
+    mode: "g+rx,o+rx"
+
+- name: Read node-token from master
+  become: true
+  ansible.builtin.slurp:
+    path: "{{ k3s_server_location }}/server/node-token"
+  register: node_token
+
+- name: Store Master node-token
+  become: true
+  ansible.builtin.set_fact:
+    token: "{{ node_token.content | b64decode | regex_replace('\n', '') }}"
+
+- name: Restore node-token file access
+  become: true
+  ansible.builtin.file:
+    path: "{{ k3s_server_location }}/server/node-token"
+    mode: "{{ p.stat.mode }}"
+
+- name: Create directory .kube
+  ansible.builtin.file:
+    path: ~{{ ansible_user_id }}/.kube
+    state: directory
+    owner: "{{ ansible_user_id }}"
+    mode: "u=rwx,g=rx,o="
+
+- name: Copy config file to user home directory
+  become: true
+  ansible.builtin.copy:
+    src: "{{ k3s_conf_location }}/k3s.yaml"
+    dest: ~{{ ansible_user_id }}/.kube/config
+    remote_src: yes
+    owner: "{{ ansible_user_id }}"
+    mode: "u=rw,g=,o="
+
+- name: Update cluster server address
+  # FIXME: should be ansible.builtin.command in later versions of Ansible
+  command: |
+    k3s kubectl config set-cluster default
+      --server=https://{{ k3s_server_ip }}:{{ k3s_port }}
+      --kubeconfig ~{{ ansible_user_id }}/.kube/config
+  changed_when: true
+
+- name: Create kubectl symlink
+  become: true
+  ansible.builtin.file:
+    src: /usr/local/bin/k3s
+    dest: /usr/local/bin/kubectl
+    state: link
+
+- name: Create crictl symlink
+  become: true
+  ansible.builtin.file:
+    src: /usr/local/bin/k3s
+    dest: /usr/local/bin/crictl
+    state: link
+
+- name: Copy debug manifests
+  become: true
+  ansible.builtin.copy:
+    src: "{{ item }}"
+    dest: "{{ k3s_conf_location }}/"
+    owner: root
+    group: root
+    mode: 0755
+  with_fileglob: "debug-*.yaml"

--- a/roles/k3s/tasks/config-k3s-service.yml
+++ b/roles/k3s/tasks/config-k3s-service.yml
@@ -1,0 +1,62 @@
+---
+- name: Download and install k3s binary
+  become: true
+  ansible.builtin.get_url:
+    url: https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/k3s
+    checksum: sha256:https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/sha256sum-amd64.txt
+    dest: /usr/local/bin/k3s
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Copy K3s env file
+  become: true
+  ansible.builtin.template:
+    src: "k3s.env.j2"
+    dest: /etc/default/k3s
+    owner: root
+    group: root
+    mode: 0600
+
+- set_fact:
+    kolla_external_vip_address_family: ipv4
+
+- name: Ensure k3s conf dir exists
+  become: true
+  ansible.builtin.file:
+    path: "{{ k3s_conf_location }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Copy K3s config file
+  become: true
+  ansible.builtin.template:
+    src: "config.yaml.j2"
+    dest: "{{ k3s_conf_location }}/config.yaml"
+    owner: root
+    group: root
+    mode: 0644
+  vars:
+    # This _address_family var is not set by default; this is just to make kolla_address
+    # happy when it tries to template the primary address of the VIP interface.
+    kolla_external_vip_address_family: ipv4
+
+- name: Copy K3s systemd service file
+  register: k3s_service
+  become: true
+  ansible.builtin.template:
+    src: "k3s.service.j2"
+    dest: "{{ k3s_systemd_dir }}/k3s.service"
+    owner: root
+    group: root
+    mode: 0644
+
+- name: Enable and check K3s service
+  become: true
+  systemd:
+    name: k3s
+    daemon_reload: yes
+    state: started
+    enabled: yes

--- a/roles/k3s/tasks/config-neutron.yml
+++ b/roles/k3s/tasks/config-neutron.yml
@@ -1,0 +1,51 @@
+---
+- name: Create calico network
+  kolla_toolbox:
+    module_name: os_network
+    module_args:
+      auth: "{{ openstack_auth }}"
+      name: caliconet
+      provider_network_type: flat
+      provider_physical_network: calico
+      shared: yes
+      state: present
+  run_once: true
+  become: yes
+
+- name: Create calico subnet
+  kolla_toolbox:
+    module_name: os_subnet
+    module_args:
+      auth: "{{ openstack_auth }}"
+      network_name: caliconet
+      name: caliconet-subnet
+      cidr: "{{ k3s_cluster_cidr }}"
+      enable_dhcp: no
+  become: yes
+
+# FIXME(jason): this doesn't actually add the subnet to the router!
+# When we have updated to a later Ansible we can potentially fetch the router's
+# interfaces with routers_info and then merge this interface into the list?
+- name: Fetch existing NAT router
+  kolla_toolbox:
+    module_name: os_router
+    module_args:
+      auth: "{{ openstack_auth }}"
+      name: sharednet-router
+      # interfaces:
+      #   - caliconet-subnet
+  register: calico_router
+  run_once: true
+  become: yes
+
+- name: Generate Calico/Neutron connection script
+  ansible.builtin.template:
+    src: neutron-calico-connect.j2
+    dest: "{{ k3s_conf_location }}/neutron-calico-connect.sh"
+    owner: root
+    group: root
+    mode: "0700"
+  vars:
+    neutron_router_id: "{{ calico_router.router.id }}"
+  when:
+    - k3s_enable_calico | bool

--- a/roles/k3s/tasks/config-registry-proxy.yml
+++ b/roles/k3s/tasks/config-registry-proxy.yml
@@ -1,0 +1,14 @@
+---
+- name: Template deployment for registry proxy
+  ansible.builtin.template:
+    src: "docker-registry-deployment.yaml.j2"
+    dest: "{{ k3s_conf_location }}/docker-registry-deployment.yaml"
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Apply deployment for registry proxy
+  command: >-
+    kubectl apply -f {{ k3s_conf_location }}/docker-registry-deployment.yaml
+  when:
+    - not (k3s_dry_run | bool)

--- a/roles/k3s/tasks/main.yml
+++ b/roles/k3s/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- include_tasks: config-k3s-service.yml
+- include_tasks: config-k3s-client.yml
+
+- include_tasks: config-calico.yml
+  when: k3s_enable_calico | bool
+
+- include_tasks: config-device-plugins.yml
+
+- include_tasks: config-neutron.yml
+  when: enable_neutron | bool
+
+- include_tasks: config-registry-proxy.yml
+  when: k3s_enable_registry_proxy | bool

--- a/roles/k3s/templates/calico-custom-resources.yaml.j2
+++ b/roles/k3s/templates/calico-custom-resources.yaml.j2
@@ -1,0 +1,47 @@
+# {{ ansible_managed }}
+# This is based on the default value of the installation configuration found at
+# https://raw.githubusercontent.com/projectcalico/calico/v3.24.1/manifests/custom-resources.yaml
+
+# This section includes base Calico installation configuration.
+# For more information, see: https://projectcalico.docs.tigera.io/reference/installation/api#operator.tigera.io/v1.Installation
+apiVersion: operator.tigera.io/v1
+kind: Installation
+metadata:
+  name: default
+spec:
+  controlPlaneNodeSelector:
+    node-role.kubernetes.io/control-plane: "true"
+  # Configures Calico networking.
+  calicoNetwork:
+    # Note: The ipPools section cannot be modified post-install.
+    ipPools:
+      - cidr: {{ k3s_cluster_cidr }}
+        blockSize: {{ k3s_cluster_node_blocksize }}
+        encapsulation: IPIP
+        natOutgoing: Enabled
+        nodeSelector: all()
+    # Ensure calico uses the last Wireguard interface
+    nodeAddressAutodetectionV4:
+      firstFound: false
+      interface: wg-.*
+    containerIPForwarding: Enabled
+    # Lower MTU to accommodate Wireguard encapsulation; Calico uses IPIP encapsulation
+    # which adds a 20-byte overhead. The underlying Wireguard interface has an MTU of
+    # 1420 configured, so we subtract 20 to get 1400.
+    mtu: 1400
+  # TODO(jason): remove this when we have a pull-through cache deployed
+  # Pull control plane images for Calico from our private registry to avoid rate limits.
+  imagePullSecrets:
+    - name: chi-readonly-secret
+      registry: docker.chameleoncloud.org/
+
+---
+
+# This section configures the Calico API server.
+# For more information, see: https://docs.projectcalico.org/v3.21/reference/installation/api#operator.tigera.io/v1.APIServer
+apiVersion: operator.tigera.io/v1
+kind: APIServer
+metadata:
+  name: default
+spec: {}
+

--- a/roles/k3s/templates/config.yaml.j2
+++ b/roles/k3s/templates/config.yaml.j2
@@ -1,0 +1,14 @@
+---
+cluster-cidr: {{ k3s_cluster_cidr }}
+# HA for K3s is not yet supported; there is no HAProxy frontend serving the traffic
+# to the API. Once that is functional, we can use the VIP address here.
+bind-address: {{ k3s_server_ip }}
+node-external-ip: {{ k3s_server_ip }}
+secrets-encryption: True
+{% if k3s_enable_calico | bool %}
+flannel-backend: none
+disable-network-policy: True
+disable:
+  - servicelb
+  - traefik
+{% endif %}

--- a/roles/k3s/templates/docker-registry-deployment.yaml.j2
+++ b/roles/k3s/templates/docker-registry-deployment.yaml.j2
@@ -1,0 +1,50 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: docker-registry
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: docker-registry
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: docker-registry
+    spec:
+      containers:
+      - resources:
+        name: registry
+        image: registry:2
+        ports:
+        - name: registry-port
+          containerPort: 5000
+        volumeMounts:
+        - mountPath: /var/lib/registry
+          name: registry-data
+        env:
+        - name: REGISTRY_PROXY_REMOTEURL
+          value: https://registry-1.docker.io
+        - name: REGISTRY_STORAGE_DELETE_ENABLED
+          value: "true"
+      volumes:
+      - name: registry-data
+        hostPath:
+          path: /var/lib/registry
+      nodeSelector:
+        node-role.kubernetes.io/master: "true"
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: docker-registry
+spec:
+  selector:
+    app.kubernetes.io/name: docker-registry
+  ports:
+  - name: registry-port
+    protocol: TCP
+    port: 80
+    targetPort: registry-port

--- a/roles/k3s/templates/k3s.env.j2
+++ b/roles/k3s/templates/k3s.env.j2
@@ -1,0 +1,1 @@
+K3S_CONFIG_FILE={{ k3s_conf_location }}/config.yaml

--- a/roles/k3s/templates/k3s.service.j2
+++ b/roles/k3s/templates/k3s.service.j2
@@ -1,0 +1,25 @@
+[Unit]
+Description=Lightweight Kubernetes
+Documentation=https://k3s.io
+After=network-online.target
+
+[Service]
+Type=notify
+EnvironmentFile=-/etc/default/%N
+ExecStartPre=-/sbin/modprobe br_netfilter
+ExecStartPre=-/sbin/modprobe overlay
+ExecStart=/usr/local/bin/k3s server --data-dir {{ k3s_server_location }} {{ k3s_extra_server_args | default("") }}
+KillMode=process
+Delegate=yes
+# Having non-zero Limit*s causes performance problems due to accounting overhead
+# in the kernel. We recommend using cgroups to do container-local accounting.
+LimitNOFILE=1048576
+LimitNPROC=infinity
+LimitCORE=infinity
+TasksMax=infinity
+TimeoutStartSec=0
+Restart=always
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/k3s/templates/neutron-calico-connect.j2
+++ b/roles/k3s/templates/neutron-calico-connect.j2
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# {{ ansible_managed }}
+#
+# Bridges Neutron to the Calico network for the purposes of assigning Floating IP
+# addresses to pods running on K3s.
+
+calico_cidr="{{ k3s_cluster_cidr }}"
+host_addr="192.168.150.1/24"
+ns_addr="192.168.150.2/24"
+
+neutron_ns=qrouter-"{{ neutron_router_id }}"
+
+# Create veth pair to connect Neutron router ns to default ns
+ip link show veth-cali0 >/dev/null || ip link add veth-cali0 type veth peer veth-caliN
+
+ip link set veth-cali0 up
+ip addr replace "$host_addr" dev veth-cali0
+
+ip link set veth-caliN netns "$neutron_ns" up
+ip netns exec "$neutron_ns" ip addr replace "$ns_addr" dev veth-caliN
+
+# Allow traffic from Neutron router ns to travel through default ns for Calico subnet
+# Also ensure we delete Neutron's default route it adds due to the subnet having a
+# router interface.
+ip netns exec "$neutron_ns" ip route replace "$calico_cidr" via "${host_addr%%/24}"
+
+# Required for any traffic going over IPIP tunnel to other Calico nodes
+iptables -t nat -S | grep -q neutron-calico-connect:01 || {
+  iptables -t nat -A POSTROUTING -o tunl0 -j MASQUERADE \
+    -m comment --comment "(neutron-calico-connect:01) bridge Neutron floating IPs to K3s"
+}
+# Floating IPs normally do DNAT, which does not change the source address. This breaks
+# Calico, which does not understand how to return the packets.
+iptables -t nat -S | grep -q neutron-calico-connect:02 || {
+  ip netns exec "$neutron_ns" iptables -t nat -A POSTROUTING -o veth-caliN -J MASQUERADE \
+    -m comment --comment "(neutron-calico-connect:02) rewrite source for Calico-bound packets"
+}

--- a/roles/k3s/templates/smarter-device-manager-ds-jetson.yaml.j2
+++ b/roles/k3s/templates/smarter-device-manager-ds-jetson.yaml.j2
@@ -1,0 +1,113 @@
+# This file is a synthesis of smarter-device-manager-configmap-xavier.yaml and smarter-device-manager-ds.yaml
+# from the smarter-device-manager repo[0].
+# [0]: https://gitlab.com/arm-research/smarter/smarter-device-manager/
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: smarter-device-manager-system
+  labels:
+    name: smarter-device-manager-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: smarter-device-manager-system
+  name: smarter-device-manager-jetson
+data:
+  conf.yaml: |
+    - devicematch: ^snd$
+      nummaxdevices: 20
+    - devicematch: ^gpiomem$
+      nummaxdevices: 40
+    - devicematch: ^gpiochip[0-9]*$
+      nummaxdevices: 20
+    - devicematch: ^hci[0-9]*$
+      nummaxdevices: 1
+    - devicematch: ^i2c-[0-9]*$
+      nummaxdevices: 1
+    - devicematch: ^rtc0$
+      nummaxdevices: 20
+    - devicematch: ^video[0-9]*$
+      nummaxdevices: 20
+    - devicematch: ^vchiq$
+      nummaxdevices: 20
+    - devicematch: ^vcsm.*$
+      nummaxdevices: 20
+    - devicematch: ^ttyUSB[0-9]*$
+      nummaxdevices: 1
+    - devicematch: ^ttyACM[0-9]*$
+      nummaxdevices: 1
+    - devicematch: ^ttyTHS[0-9]*$
+      nummaxdevices: 1
+    - devicematch: ^ttyS[0-9]*$
+      nummaxdevices: 1
+    - devicematch: nvidia-gpu
+      nummaxdevices: 20
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  namespace: smarter-device-manager-system
+  name: smarter-device-manager-jetson
+  labels:
+    # FIXME: not sure if labels.name is also needed if we already have 'name' above
+    name: smarter-device-manager-jetson
+    role: agent
+spec:
+  selector:
+    matchLabels:
+      smarter-device-manager/configmap: jetson
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        smarter-device-manager/configmap: jetson
+      annotations:
+        node.kubernetes.io/bootstrap-checkpoint: "true"
+    spec:
+      nodeSelector:
+        smarter-device-manager: enabled
+        smarter-device-manager/configmap: jetson
+      priorityClassName: "system-node-critical"
+      hostname: smarter-device-management
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: smarter-device-manager
+          image: registry.gitlab.com/arm-research/smarter/smarter-device-manager:{{ k3s_smarter_device_plugin_version }}
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            limits:
+              cpu: 100m
+              memory: 15Mi
+            requests:
+              cpu: 10m
+              memory: 15Mi
+          volumeMounts:
+            - name: device-plugin
+              mountPath: /var/lib/kubelet/device-plugins
+            - name: dev-dir
+              mountPath: /dev
+            - name: sys-dir
+              mountPath: /sys
+            - name: config
+              mountPath: /root/config
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins
+        - name: dev-dir
+          hostPath:
+            path: /dev
+        - name: sys-dir
+          hostPath:
+            path: /sys
+        - name: config
+          configMap:
+            name: smarter-device-manager-jetson
+      terminationGracePeriodSeconds: 30

--- a/roles/k3s/templates/smarter-device-manager-ds-rpi.yaml.j2
+++ b/roles/k3s/templates/smarter-device-manager-ds-rpi.yaml.j2
@@ -1,0 +1,111 @@
+# This file is a synthesis of smarter-device-manager-configmap-rpi.yaml and smarter-device-manager-ds.yaml
+# from the smarter-device-manager repo[0].
+# [0]: https://gitlab.com/arm-research/smarter/smarter-device-manager/
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: smarter-device-manager-system
+  labels:
+    name: smarter-device-manager-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: smarter-device-manager-system
+  name: smarter-device-manager-rpi
+data:
+  conf.yaml: |
+    - devicematch: ^snd$
+      nummaxdevices: 20
+    - devicematch: ^gpiomem$
+      nummaxdevices: 40
+    - devicematch: ^gpiochip[0-9]*$
+      nummaxdevices: 20
+    - devicematch: ^hci[0-9]*$
+      nummaxdevices: 1
+    - devicematch: ^i2c-[0-9]*$
+      nummaxdevices: 1
+    - devicematch: ^rtc0$
+      nummaxdevices: 20
+    - devicematch: ^video[0-9]*$
+      nummaxdevices: 20
+    - devicematch: ^vchiq$
+      nummaxdevices: 20
+    - devicematch: ^vcsm.*$
+      nummaxdevices: 20
+    - devicematch: ^ttyUSB[0-9]*$
+      nummaxdevices: 1
+    - devicematch: ^ttyACM[0-9]*$
+      nummaxdevices: 1
+    - devicematch: ^ttyTHS[0-9]*$
+      nummaxdevices: 1
+    - devicematch: ^ttyS[0-9]*$
+      nummaxdevices: 1
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  namespace: smarter-device-manager-system
+  name: smarter-device-manager-rpi
+  labels:
+    # FIXME: not sure if labels.name is also needed if we already have 'name' above
+    name: smarter-device-manager-rpi
+    role: agent
+spec:
+  selector:
+    matchLabels:
+      smarter-device-manager/configmap: rpi
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        smarter-device-manager/configmap: rpi
+      annotations:
+        node.kubernetes.io/bootstrap-checkpoint: "true"
+    spec:
+      nodeSelector:
+        smarter-device-manager: enabled
+        smarter-device-manager/configmap: rpi
+      priorityClassName: "system-node-critical"
+      hostname: smarter-device-management
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: smarter-device-manager
+          image: registry.gitlab.com/arm-research/smarter/smarter-device-manager:{{ k3s_smarter_device_plugin_version }}
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            limits:
+              cpu: 100m
+              memory: 15Mi
+            requests:
+              cpu: 10m
+              memory: 15Mi
+          volumeMounts:
+            - name: device-plugin
+              mountPath: /var/lib/kubelet/device-plugins
+            - name: dev-dir
+              mountPath: /dev
+            - name: sys-dir
+              mountPath: /sys
+            - name: config
+              mountPath: /root/config
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins
+        - name: dev-dir
+          hostPath:
+            path: /dev
+        - name: sys-dir
+          hostPath:
+            path: /sys
+        - name: config
+          configMap:
+            name: smarter-device-manager-rpi
+      terminationGracePeriodSeconds: 30

--- a/roles/post_networking/defaults/main.yml
+++ b/roles/post_networking/defaults/main.yml
@@ -9,3 +9,6 @@ shared_network: "{{ shared_networks[0] if shared_networks }}"
 
 default_sharednet_name: sharednet1
 default_sharednet_cidr: 10.0.0.1/24
+
+# Default to using the external VIP interface for NAT
+corsa_nat_external_interface: "{{ kolla_external_vip_interface }}"

--- a/roles/post_networking/tasks/corsa_nat.yml
+++ b/roles/post_networking/tasks/corsa_nat.yml
@@ -1,0 +1,19 @@
+---
+- name: add networkd-dispatcher hook for corsa nat
+  become: True
+  ansible.builtin.template:
+    src: 50-corsa-nat.sh.j2
+    dest: /etc/networkd-dispatcher/routable.d/50-corsa-nat.sh
+    owner: root
+    group: root
+    mode: "0755"
+  when:
+    - corsa_nat_network_cidr is defined
+
+- name: Remove hook when not enabled
+  become: True
+  ansible.builtin.file:
+    path: /etc/networkd-dispatcher/routable.d/50-corsa-nat.sh
+    state: absent
+  when:
+    - corsa_nat_network_cidr is not defined

--- a/roles/post_networking/tasks/main.yml
+++ b/roles/post_networking/tasks/main.yml
@@ -3,3 +3,5 @@
   include_tasks: public.yml
 - name: configure shared tenant network(s) and subnet(s)
   include_tasks: sharednet.yml
+- name: configure corsa nat interface
+  include_tasks: corsa_nat.yml

--- a/roles/post_networking/templates/50-corsa-nat.sh.j2
+++ b/roles/post_networking/templates/50-corsa-nat.sh.j2
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# This file is managed by ansible, don't edit it manually.
+
+CORSA_SUBNET={{ corsa_nat_network_cidr }}
+PUBLIC_IFACE={{ corsa_nat_external_interface }}
+
+# this script will enable NAT on the configured interface
+if [[ $IFACE == "$PUBLIC_IFACE" && $AdministrativeState == "configured" ]]; then
+    echo "Enabling NAT from subnet ${CORSA_SUBNET} via outbound interface ${PUBLIC_IFACE}" >> /var/log/syslog
+    iptables -t nat -A POSTROUTING -s "${CORSA_SUBNET}" -o "${PUBLIC_IFACE}" -j MASQUERADE
+fi
+
+exit 0

--- a/site-config.example/defaults.yml
+++ b/site-config.example/defaults.yml
@@ -180,6 +180,12 @@ neutron_networks:
 
 # ironic_provisioning_network_cidr: 10.51.0.0/24
 
+# For provisioning, nodes netboot a kernel and ramdisk with the ironic-python-agent. These images are added to glance
+# during post-deploy. The values below will be used by default, but can be overridden on specific nodes if needed. This may
+# need to be done to handle other architectures, such as ARM64, or for other cases with specialized hardware.
+# deploy_kernel = "<deploy_kernel_glance_uuid>"
+# deploy_ramdisk = "<deploy_ramdisk_glance_uuid>"
+
 
 ################################
 # Baremetal switch configuration

--- a/site-config.example/inventory/hosts
+++ b/site-config.example/inventory/hosts
@@ -44,6 +44,10 @@ mariadb
 [precis:children]
 control
 
+# used for CHI@Edge v2 deployment
+[k3s:children]
+control
+
 [redfish-monitor:children]
 control
 
@@ -682,6 +686,9 @@ zun
 
 [zun-compute:children]
 compute
+
+[zun-compute-k8s:children]
+zun
 
 [zun-cni-daemon:children]
 compute

--- a/site-config.example/inventory/hosts
+++ b/site-config.example/inventory/hosts
@@ -779,6 +779,9 @@ monitoring
 [prometheus-ipmi-exporter:children]
 ironic-conductor
 
+[prometheus-ironic-exporter:children]
+ironic-conductor
+
 [prometheus-redis-exporter:children]
 redis
 


### PR DESCRIPTION
this globalnetwork  policy can be used to prevent egress from a
host to private IPs. This policy targets hostendpoints, which in turn
define which host interfaces are affected.

As it affects flows passing through said host interfaces, it acts to
restrict policy that targets workloads, rather than interfaces.

Example:

Namespaced networkpolicy permits egress traffic from container1 to container2
within the same namespace. As the destination is a known endpoint to calico,
it is included in "selector: all()" in the allow block of this policy, and the
Deny rule is not applied, despite traffic going to a private IP.

However, traffic from said container1 OR from services on the host itself to a
private IP not present in kubernetes, will be blocked by the second rule.

WARNING:
It's not clear what will happen in the case where a kubernetes endpoint exists that
overlaps with a local IP address.