### PR TITLE
Install compatible version of PyOpenSSL

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,9 @@
 ansible>=2.10,<=4
+
+# ensure the version of pyopenssl installed is compatible with cryptography. May be resolved after ansible 5.x
+# https://github.com/pyca/pyopenssl/issues/1114
+pyopenssl
+
 # Jinja2 3.1 breaks filters, removes py3.6 support
 # See https://jinja.palletsprojects.com/en/3.1.x/changes/#version-3-1-0
 jinja2<3.1.0


### PR DESCRIPTION
The installed version of cryptography and pyopenssl may become
out of sync. Ensure the latest pyopenssl is installed to fix this.
See https://github.com/pyca/pyopenssl/issues/1114