### PR TITLE
Bump ansible version to 4.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
-ansible>=2.10,<=4
+# Xena release of Kolla-ansible requires ansible release between 2.10 and below 5.x,
+# This is because it depends on ansible-core 2.11.x
+# See https://docs.openstack.org/releasenotes/kolla-ansible/xena.html#relnotes-13-0-0-stable-xena-upgrade-notes
+ansible>=2.10,<5
 
 # ensure the version of pyopenssl installed is compatible with cryptography. May be resolved after ansible 5.x
 # https://github.com/pyca/pyopenssl/issues/1114


### PR DESCRIPTION
An incorrect version specifier was used, limiting the ansible version to v4.0.0. Although EoL, ansible major release 4.x is the latest supported by kolla-ansible's xena release, due to dependency on ansible-core v2.11.x.

Note: Ansible-core v2.11.x will itself go EoL in November 2022. See:
- https://docs.openstack.org/releasenotes/kolla-ansible/xena.html#relnotes-13-0-0-stable-xena-upgrade-notes
- https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html