### PR TITLE
add sso config for grafana

### DIFF
--- a/kolla/node_custom_config/grafana.ini
+++ b/kolla/node_custom_config/grafana.ini
@@ -1,0 +1,21 @@
+[server]
+root_url = "https://{{kolla_external_fqdn}}:3000"
+
+[auth]
+disable_login_form = "true"
+oauth_auto_login = "true"
+
+[auth.generic_oauth]
+name = Chameleon
+icon = signin
+enabled = true
+allow_sign_up = true
+client_id = "{{ keystone_idp_client_id }}"
+scopes = openid profile email
+auth_url = "https://auth.chameleoncloud.org/auth/realms/chameleon/protocol/openid-connect/auth"
+token_url = "https://auth.chameleoncloud.org/auth/realms/chameleon/protocol/openid-connect/token"
+api_url = "https://auth.chameleoncloud.org/auth/realms/chameleon/protocol/openid-connect/userinfo"
+
+role_attribute_path = contains(projects[*].id, 'Chameleon') && 'Admin' || contains(projects[*].id, 'CHI-210828') && 'Editor'
+# deny login if a role is not matched by role_attribute_path
+role_attribute_strict = true


### PR DESCRIPTION
This PR adds single-sign-on for Grafana.

TODO: Template list of allowed groups for admin, editor, and viewer roles

NOTE: we cannot allow public  access to the primary grafana instance/org, as viewers can run any possible query on any datasource. See https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/#limit-viewer-query-permissions
