### PR TITLE
Automatically set `kolla_externally_managed_cert` when Let's Encrypt is enabled

### DIFF
--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -108,6 +108,7 @@ enable_haproxy: yes
 haproxy_listen_neutron_server_extra: ["timeout server 15m"]
 haproxy_service_template: "haproxy_single_service_split.cfg.j2"
 kolla_external_fqdn_cert: "{{ cc_ansible_site_dir }}/certificates/haproxy.pem"
+kolla_externally_managed_cert: "{{ enable_letsencrypt | bool }}"
 
 # Heat
 enable_heat: yes


### PR DESCRIPTION
In general, users will want this enabled if they're using Let's Encrypt. It could cause confusion for new deployments, but this should no longer be an issue when #116 is figured out.
