### PR TITLE
add prometheus ironic exporter

### DIFF
--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -167,6 +167,10 @@ ironic_console_serial_speed: 115200n8
 encoded_ironic_pxe_root_password: "{{ ironic_pxe_root_password | password_hash('md5') |  regex_replace( '(\\$)', '$\\1') }}"
 ironic_pxe_append_params: nofb nomodeset vga=normal console=tty0 console=ttyS0,{{ ironic_console_serial_speed }} systemd.journald.forward_to_console=yes rootpwd="{{ encoded_ironic_pxe_root_password }}"
 
+# This can be "expensive"; allow setting it explicitly, but default to the prometheus interval
+ironic_send_sensor_data_interval: 60
+ironic_send_sensor_data_for_undeployed_nodes: False
+
 # number of times to retry failed neutron api requests
 # will use exponential backoff from 0.5s up to 60s, or
 # will use ironic_neutron_status_code_retry_delay if set
@@ -278,6 +282,9 @@ prometheus_openstack_exporter_cmdline_extras: >-
 prometheus_server_external_url: "{{ public_protocol }}://{{ prometheus_external_fqdn }}:{{ prometheus_port }}"
 prometheus_alertmanager_external_url: "{{ public_protocol }}://{{ prometheus_external_fqdn }}:{{ prometheus_alertmanager_port }}"
 prometheus_bind_address: "{{ lookup('vars', 'ansible_' + network_interface).ipv4.address }}"
+
+enable_prometheus_ironic_exporter: "{{ enable_prometheus | bool and enable_ironic | bool }}"
+# prometheus_ironic_exporter_interval: 60s
 
 # Redfish Monitor
 redfish_monitor_openstack_user: "{{ keystone_admin_username }}"

--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -284,7 +284,6 @@ prometheus_alertmanager_external_url: "{{ public_protocol }}://{{ prometheus_ext
 prometheus_bind_address: "{{ lookup('vars', 'ansible_' + network_interface).ipv4.address }}"
 
 enable_prometheus_ironic_exporter: "{{ enable_prometheus | bool and enable_ironic | bool }}"
-# prometheus_ironic_exporter_interval: 60s
 
 # Redfish Monitor
 redfish_monitor_openstack_user: "{{ keystone_admin_username }}"

--- a/kolla/node_custom_config/ironic.conf
+++ b/kolla/node_custom_config/ironic.conf
@@ -23,6 +23,8 @@ port_range = 40000:50000
 [conductor]
 # We do not perform automated cleaning to improve turnaround time on a node.
 automated_clean = False
+send_sensor_data_interval = "{{ ironic_send_sensor_data_interval }}"
+send_sensor_data_for_undeployed_nodes = "{{ ironic_send_sensor_data_for_undeployed_nodes }}"
 
 # deploy kernel and ramdisk to use if not set on node
 {% if ironic_deploy_kernel is defined %}
@@ -49,6 +51,12 @@ status_code_retry_delay = "{{ ironic_neutron_status_code_retry_delay }}"
 [oslo_messaging_notifications]
 # Experiment Precis requires 2.0 message format, i.e. set driver to messagingv2
 driver = messagingv2
+
+# driver is a list, but ini merging breaks that. Set it again here.
+{% if enable_prometheus_ironic_exporter | bool %}
+driver = prometheus_exporter
+location = /opt/stack/node_metrics
+{% endif %}
 
 [pxe]
 pxe_append_params = "{{ ironic_pxe_append_params }}"

--- a/site-config.example/inventory/hosts
+++ b/site-config.example/inventory/hosts
@@ -779,6 +779,9 @@ monitoring
 [prometheus-ipmi-exporter:children]
 ironic-conductor
 
+[prometheus-ironic-exporter:children]
+ironic-conductor
+
 [prometheus-redis-exporter:children]
 redis
 


### PR DESCRIPTION
This PR adds the [prometheus ironic exporter](https://opendev.org/openstack/ironic-prometheus-exporter) to export metrics about all nodes known to ironic.

This depends on the following PRs:
- [x] https://github.com/ChameleonCloud/kolla/pull/8
- [x] https://github.com/ChameleonCloud/kolla-containers/pull/32
- [x] https://github.com/ChameleonCloud/kolla-ansible/pull/31
