### PR TITLE
Add networkd-dispatcher hook for corsa NAT

### DIFF
--- a/roles/post_networking/defaults/main.yml
+++ b/roles/post_networking/defaults/main.yml
@@ -9,3 +9,6 @@ shared_network: "{{ shared_networks[0] if shared_networks }}"
 
 default_sharednet_name: sharednet1
 default_sharednet_cidr: 10.0.0.1/24
+
+# Default to using the external VIP interface for NAT
+corsa_nat_external_interface: "{{ kolla_external_vip_interface }}"

--- a/roles/post_networking/tasks/corsa_nat.yml
+++ b/roles/post_networking/tasks/corsa_nat.yml
@@ -1,0 +1,19 @@
+---
+- name: add networkd-dispatcher hook for corsa nat
+  become: True
+  ansible.builtin.template:
+    src: 50-corsa-nat.sh.j2
+    dest: /etc/networkd-dispatcher/routable.d/50-corsa-nat.sh
+    owner: root
+    group: root
+    mode: "0755"
+  when:
+    - corsa_nat_network_cidr is defined
+
+- name: Remove hook when not enabled
+  become: True
+  ansible.builtin.file:
+    path: /etc/networkd-dispatcher/routable.d/50-corsa-nat.sh
+    state: absent
+  when:
+    - corsa_nat_network_cidr is not defined

--- a/roles/post_networking/tasks/main.yml
+++ b/roles/post_networking/tasks/main.yml
@@ -3,3 +3,5 @@
   include_tasks: public.yml
 - name: configure shared tenant network(s) and subnet(s)
   include_tasks: sharednet.yml
+- name: configure corsa nat interface
+  include_tasks: corsa_nat.yml

--- a/roles/post_networking/templates/50-corsa-nat.sh.j2
+++ b/roles/post_networking/templates/50-corsa-nat.sh.j2
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# This file is managed by ansible, don't edit it manually.
+
+CORSA_SUBNET={{ corsa_nat_network_cidr }}
+PUBLIC_IFACE={{ corsa_nat_external_interface }}
+
+# this script will enable NAT on the configured interface
+if [[ $IFACE == "$PUBLIC_IFACE" && $AdministrativeState == "configured" ]]; then
+    echo "Enabling NAT from subnet ${CORSA_SUBNET} via outbound interface ${PUBLIC_IFACE}" >> /var/log/syslog
+    iptables -t nat -A POSTROUTING -s "${CORSA_SUBNET}" -o "${PUBLIC_IFACE}" -j MASQUERADE
+fi
+
+exit 0


### PR DESCRIPTION
Enable corsa NAT via networkd-dispatche hook.
This is needed to allow the corsa switches to "reach out" to openflow controllers running on public networks.

Required config variables:
- `corsa_nat_network_cidr`
- `corsa_nat_external_interface`

Actually creating the interface that corsas connect to (vlan3289 for UC), is out of scope for this PR, and should be done in e.g. the netplan or other persistent networking configuration.