### PR TITLE
209-chiedge-depending-on-label-block-traffic-to-local-networks

### DIFF
--- a/roles/k3s/files/calico-global-networkpolicy-host.yaml
+++ b/roles/k3s/files/calico-global-networkpolicy-host.yaml
@@ -1,0 +1,89 @@
+---
+# enable auto host-endpoints
+# https://projectcalico.docs.tigera.io/reference/resources/kubecontrollersconfig
+apiVersion: projectcalico.org/v3
+kind: KubeControllersConfiguration
+metadata:
+  name: default
+spec:
+  controllers:
+    node:
+      hostEndpoint:
+        autoCreate: Enabled
+      syncLabels: Enabled
+---
+# define failsafe ports for felix
+apiVersion: projectcalico.org/v3
+kind: FelixConfiguration
+metadata:
+  name: default
+spec:
+  failsafeInboundHostPorts:
+    - port: 22
+      protocol: tcp
+    - port: 68
+      protocol: udp
+    - port: 179
+      protocol: tcp
+    - port: 2379
+      protocol: tcp
+    - port: 2380
+      protocol: tcp
+    - port: 5473
+      protocol: tcp
+    - port: 6443
+      protocol: tcp
+    - port: 6666
+      protocol: tcp
+    - port: 6667
+      protocol: tcp
+  failsafeOutboundHostPorts:
+    - port: 53
+      protocol: udp
+    - port: 67
+      protocol: udp
+    - port: 179
+      protocol: tcp
+    - port: 2379
+      protocol: tcp
+    - port: 2380
+      protocol: tcp
+    - port: 5473
+      protocol: tcp
+    - port: 6443
+      protocol: tcp
+    - port: 6666
+      protocol: tcp
+    - port: 6667
+      protocol: tcp
+    - port: 9099
+      protocol: tcp
+    - port: 10010
+      protocol: tcp
+    - port: 10250
+      protocol: tcp
+---
+apiVersion: projectcalico.org/v3
+kind: GlobalNetworkPolicy
+metadata:
+  name: edge-host-worker
+spec:
+  selector: "chi.edge/local_egress == 'deny'"
+  applyOnForward: True # applies to all traffic through host interfaces
+  order: 100 #lowest priority, after other rules
+  types:
+    - Egress
+  egress:
+    # don't block traffic to known k8s pods,hosts,etc
+    - action: Allow
+      destination:
+        selector: all() #all endpoints known to k8s
+    # if traffic isn't going to a k8s endpoint, allow it
+    - action: Deny
+      destination:
+        nets:
+          - 10.0.0.0/8
+          - 172.16.0.0/12
+          - 192.168.0.0/16
+    # allow egress traffic not matched above
+    - action: Allow


### PR DESCRIPTION
this globalnetwork  policy can be used to prevent egress from a
host to private IPs. This policy targets hostendpoints, which in turn
define which host interfaces are affected.

As it affects flows passing through said host interfaces, it acts to
restrict policy that targets workloads, rather than interfaces.

Example:

Namespaced networkpolicy permits egress traffic from container1 to container2
within the same namespace. As the destination is a known endpoint to calico,
it is included in "selector: all()" in the allow block of this policy, and the
Deny rule is not applied, despite traffic going to a private IP.

However, traffic from said container1 OR from services on the host itself to a
private IP not present in kubernetes, will be blocked by the second rule.

WARNING:
It's not clear what will happen in the case where a kubernetes endpoint exists that
overlaps with a local IP address.