### PR TITLE
set working directory for periodic task

### DIFF
--- a/roles/chameleon_mariadb/tasks/deployment.yml
+++ b/roles/chameleon_mariadb/tasks/deployment.yml
@@ -14,3 +14,4 @@
     task_calendar: "23:00"
     task_user: "{{ mariadb_backup_task_user|default(None) }}"
     task_group: "{{ mariadb_backup_task_group|default(None) }}"
+    task_workdir: "{{ deployment_dir | default(None) }}"


### PR DESCRIPTION
Set the working directory so that cc-ansible can copy file permissions around properly. Depends on https://github.com/ChameleonCloud/ansible-role-periodic-task/pull/3