### PR TITLE
ensure config for wg agent gets templated

### DIFF
--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -235,6 +235,9 @@ neutron_dev_plugins:
     packages:
       - networking_generic_switch
 
+# minimal config for neutron wireguard agent
+neutron_wireguard_hub_endpoint: "{{ kolla_external_vip_address }}"
+
 # Nova
 enable_nova: yes
 enable_nova_serialconsole_proxy: yes

--- a/kolla/node_custom_config/neutron/ml2_conf.ini
+++ b/kolla/node_custom_config/neutron/ml2_conf.ini
@@ -65,3 +65,8 @@ key_file = /etc/neutron/ssh/id_{{ switch.name }}
 {% endfor %}
 {% endfor %}
 {% endif %}
+
+{% if enable_neutron_wireguard | bool %}
+[wireguard]
+endpoint = {{ neutron_wireguard_hub_endpoint }}
+{% endif %}


### PR DESCRIPTION
ensure we template the necessary config for the neutron wireguard agent.
This was previously configured using a snippet in node-custom-config.