### PR TITLE
Zun: Workaround eventlet deadlock

### DIFF
--- a/kolla/node_custom_config/zun.conf
+++ b/kolla/node_custom_config/zun.conf
@@ -19,6 +19,10 @@ sync_container_state_interval = 15
 [compute]
 host_shared_with_nova = {% if enable_nova | bool %}true{% else %}false{% endif %}
 
+[oslo_messaging_rabbit]
+# Currently needed (Xena) to avoid eventlet deadlock issue
+heartbeat_in_pthread = false
+
 [scheduler]
 available_filters = zun.scheduler.filters.all_filters
 enabled_filters = {% if enable_blazar | bool %}BlazarFilter,{% endif %}ComputeFilter,RuntimeFilter


### PR DESCRIPTION
When this is set to true (default as of Wallaby), a pthread is used for this task. # This currently (Xena) has a bad interaction with eventlet, causing occasional deadlocks. # This appears related to, but separate from this bug in oslo.log # https://bugs.launchpad.net/oslo.log/+bug/1983863