### PR TITLE
Add setting to discern baremetal sites

### DIFF
--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -28,6 +28,8 @@ chameleon_site_name: localhost
 # Whether to show a dropdown in the Horizon GUI that provides links to other
 # Chameleon testbed sites.
 enable_chameleon_multisite: yes
+# Is this site a baremetal site?
+chameleon_is_baremetal_site: no
 # Default networking fallbacks
 switch_configs: []
 neutron_networks: []

--- a/kolla/node_custom_config/horizon/custom_local_settings
+++ b/kolla/node_custom_config/horizon/custom_local_settings
@@ -32,6 +32,11 @@ CHAMELEON_SITES = {
 {% endfor %}
 }
 {% endif %}
+{% if chameleon_is_baremetal_site | bool %}
+CHAMELEON_IS_BAREMETAL_SITE = True
+{% else %}
+CHAMELEON_IS_BAREMETAL_SITE = False
+{% endif %}
 
 SITE_BRANDING = 'ChameleonCloud'
 


### PR DESCRIPTION
This change introduces a new configuration parameter which allows sites to distinguish themselves as baremetal. This allows for distinct configuration between baremetal and other sites.
