### PR TITLE
disable system-site-packages when creating virtualenv

### DIFF
--- a/cc-ansible
+++ b/cc-ansible
@@ -11,7 +11,7 @@ VIRTUALENV="$(realpath "${VIRTUALENV:-"$DIR"/venv}")"
 FORCE_UPDATES="${FORCE_UPDATES:-no}"
 if [[ ! -d "$VIRTUALENV" ]]; then
   echo "Creating virtualenv at $VIRTUALENV ..."
-  python3 -m venv "$VIRTUALENV" --system-site-packages
+  python3 -m venv "$VIRTUALENV"
   "$VIRTUALENV/bin/pip" install --upgrade pip
   FORCE_UPDATES=yes
 fi


### PR DESCRIPTION
on ubuntu 22.04, package: distro-info has a conflicting version with ansible deps.
As we don't need system site packages anymore, just disable the flag.

To implement, delete the venv and rerun cc-ansible.