### PR TITLE
support etcd3gw backend for networking-generic-switch

### DIFF
--- a/kolla/node_custom_config/neutron/ml2_conf.ini
+++ b/kolla/node_custom_config/neutron/ml2_conf.ini
@@ -24,7 +24,11 @@ network_vlan_ranges =
 #
 
 [ngs_coordination]
-{% if enable_redis | bool %}
+{% if ngs_backend_url is defined %}
+backend_url = {{ngs_backend_url}}
+{% elif enable_etcd | bool %}
+backend_url = etcd3+http://{% for host in groups['etcd'] %}{% if host == groups['etcd'][0] %}{{ hostvars[host]['ansible_' + hostvars[host]['api_interface']]['ipv4']['address'] }}:{{ etcd_client_port }}{% endif %}{% endfor %}
+{% elif enable_redis | bool %}
 backend_url = redis://{% for host in groups['redis'] %}{% if host == groups['redis'][0] %}admin:{{ redis_master_password }}@{{ hostvars[host]['ansible_' + hostvars[host]['api_interface']]['ipv4']['address'] }}:{{ redis_sentinel_port }}?sentinel=kolla{% else %}&sentinel_fallback={{ hostvars[host]['ansible_' + hostvars[host]['api_interface']]['ipv4']['address'] }}:{{ redis_sentinel_port }}{% endif %}{% endfor %}&socket_timeout=60&retry_on_timeout=yes
 {% elif enable_memcached | bool %}
 backend_url = memcached://{% for host in groups['memcached'] %}{% if host == groups['memcached'][0] %}{{ hostvars[host]['ansible_' + hostvars[host]['api_interface']]['ipv4']['address'] }}:{{ memcached_port }}{% endif %}{% endfor %}


### PR DESCRIPTION
This adds the needed ml2.ini config to enable "batching" in networking-generic-switch.

To turn it on, add the following to "defaults.yml"

`enable_etcd: "yes"`

Additionally, for each switch, add
```
ngs_config:
  ngs_batch_requests: True
```