### PR TITLE
enable ironic inspector

### DIFF
--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -164,10 +164,17 @@ ironic_provisioning_network: ironic-provisioning
 ironic_provisioning_network_cidr: 10.51.0.0/24
 ironic_provisioning_network_gateway: "{{ ironic_provisioning_network_cidr | ipaddr('next_usable') }}"
 ironic_cleaning_network: "{{ ironic_provisioning_network }}"
+ironic_inspection_network: "{{ ironic_provisioning_network }}"
 ironic_image_cache_size: 20480 # MB
 ironic_console_serial_speed: 115200n8
 encoded_ironic_pxe_root_password: "{{ ironic_pxe_root_password | password_hash('md5') |  regex_replace( '(\\$)', '$\\1') }}"
 ironic_pxe_append_params: nofb nomodeset vga=normal console=tty0 console=ttyS0,{{ ironic_console_serial_speed }} systemd.journald.forward_to_console=yes rootpwd="{{ encoded_ironic_pxe_root_password }}"
+
+# settings for ironic inspector
+
+# don't run standalone, always depend on glance+neutron+ironic.
+# this means inspector won't pxe boot devices itself, and doesn't need to serve boot files to nodes
+ironic_inspector_standalone: false
 
 # This can be "expensive"; allow setting it explicitly, but default to the prometheus interval
 ironic_send_sensor_data_interval: 60

--- a/kolla/node_custom_config/ironic-inspector.conf
+++ b/kolla/node_custom_config/ironic-inspector.conf
@@ -1,0 +1,28 @@
+[processing]
+
+# Which MAC addresses to add as ports during introspection. Possible
+# values: all (all MAC addresses), active (MAC addresses of NIC with
+# IP addresses), pxe (only MAC address of NIC node PXE booted from,
+# falls back to "active" if PXE MAC is not supplied by the ramdisk).
+add_ports = all
+
+# Which ports (already present on a node) to keep after introspection.
+# Possible values: all (do not delete anything), present (keep ports
+# which MACs were present in introspection data), added (keep only
+# MACs that we added during introspection). (string value)
+keep_ports = present
+
+# Whether to overwrite existing values in node database. Disable this
+# option to make introspection a non-destructive operation. (boolean
+# value)
+overwrite_existing = False
+
+# Whether to update the pxe_enabled value according to the
+# introspection data. This option has no effect if
+# [processing]overwrite_existing is set to False (boolean value)
+#update_pxe_enabled = true
+
+# The storage backend for storing introspection data. Possible values
+# are: 'none', 'database' and 'swift'. If set to 'none', introspection
+# data will not be stored. (string value)
+store_data = database

--- a/kolla/node_custom_config/ironic.conf
+++ b/kolla/node_custom_config/ironic.conf
@@ -19,6 +19,9 @@ default_console_interface = ipmitool-socat
 
 enabled_management_interfaces = ipmitool,noop
 
+enabled_inspect_interfaces = no-inspect,inspector
+default_inspect_interface = inspector
+
 [console]
 port_range = 40000:50000
 
@@ -43,9 +46,16 @@ deploy_ramdisk = "{{ ironic_deploy_ramdisk }}"
 [deploy]
 default_boot_option = local
 
+[inspector]
+require_managed_boot = True
+# passed to ironic-python-agent, see :
+# https://docs.openstack.org/ironic-python-agent/latest/admin/how_it_works.html#inspection
+extra_kernel_params = "ipa-inspection-collectors=default,pci-devices,dmi-decode,numa-topology,logs ipa-collect-lldp=1"
+
 [neutron]
 cleaning_network = "{{ ironic_cleaning_network }}"
 provisioning_network = "{{ ironic_provisioning_network }}"
+inspection_network = "{{ ironic_inspection_network }}"
 
 {% if ironic_neutron_status_code_retries is defined %}
 status_code_retries = "{{ ironic_neutron_status_code_retries }}"

--- a/site-config.example/inventory/hosts
+++ b/site-config.example/inventory/hosts
@@ -503,7 +503,7 @@ ironic
 ironic
 
 [ironic-inspector:children]
-# Disabled; we use a separate mechanism for node property discovery
+ironic
 
 [ironic-pxe:children]
 ironic


### PR DESCRIPTION
for ironic-inspector to work with neutron, the following need to be set:

enabled_inspect_interfaces must contain `inspector`
each node must have its inspect interface set to `inspector` by
running `openstack baremetal node set --reset-inspect-interface --inspect-interface inspector`

OR, if `default_inspect_interface` is set to `inspector`, new nodes will have their interface
set to this automatically, as well as when `--reset-inspect-interface` is called.

Finally, inspection_network MUST be set, or ironic will return a cryptic error message about how
"driver IPMI does not support managed inspection".