### PR TITLE
Add polling monitor flag for blazar Floating ip and new dry run flag for polling monitor

### DIFF
--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -76,6 +76,10 @@ blazar_network_default_resource_properties: '["=", "\$stitch_provider", "none"]'
 blazar_network_retry_without_default_resources: no
 blazar_floatingip_reservation_network_regex: "[pP]ublic"
 blazar_host_url_format: "https://chameleoncloud.org/hardware/node/sites/{{ chameleon_site_name }}/clusters/chameleon/nodes/{hypervisor_hostname}/"
+blazar_physical_polling_monitor: true
+blazar_physical_polling_monitor_dry_run: true
+blazar_fip_polling_monitor: true
+blazar_fip_polling_monitor_dry_run: true
 
 # Cinder
 enable_cinder: no

--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -341,6 +341,7 @@ blazar_enable_device_plugin_k8s: "{{ enable_k3s | bool }}"
 enable_etcd: "{{ enable_zun | bool and not enable_k3s | bool }}"
 enable_kuryr: "{{ enable_zun | bool and not enable_k3s | bool }}"
 enable_zun_compute: "{{ enable_zun | bool and not enable_k3s | bool }}"
+blazar_zun_polling_monitor: true
 
 # OSG
 enable_osg: no

--- a/kolla/node_custom_config/blazar.conf
+++ b/kolla/node_custom_config/blazar.conf
@@ -47,6 +47,7 @@ heartbeat_in_pthread = false
 before_end = email
 email_relay = {{ blazar_email_relay }}
 enable_polling_monitor = true
+dry_polling_monitor = true
 retry_allocation_without_defaults = {{ blazar_host_retry_without_default_resources | bool }}
 default_resource_properties = {{ blazar_host_default_resource_properties }}
 {% endif %}
@@ -59,6 +60,7 @@ enable_polling_monitor = true
 [virtual:floatingip]
 billrate = {{ blazar_floatingip_billrate }}
 enable_polling_monitor = true
+dry_polling_monitor = true
 
 [network]
 retry_allocation_without_defaults = {{ blazar_network_retry_without_default_resources | bool }}

--- a/kolla/node_custom_config/blazar.conf
+++ b/kolla/node_custom_config/blazar.conf
@@ -58,6 +58,7 @@ enable_polling_monitor = true
 
 [virtual:floatingip]
 billrate = {{ blazar_floatingip_billrate }}
+enable_polling_monitor = true
 
 [network]
 retry_allocation_without_defaults = {{ blazar_network_retry_without_default_resources | bool }}

--- a/kolla/node_custom_config/blazar.conf
+++ b/kolla/node_custom_config/blazar.conf
@@ -46,21 +46,21 @@ heartbeat_in_pthread = false
 [physical:host]
 before_end = email
 email_relay = {{ blazar_email_relay }}
-enable_polling_monitor = true
-dry_polling_monitor = true
+enable_polling_monitor = {{ blazar_physical_polling_monitor}}
+enable_polling_monitor_dry_run = {{ blazar_physical_polling_monitor_dry_run }}
 retry_allocation_without_defaults = {{ blazar_host_retry_without_default_resources | bool }}
 default_resource_properties = {{ blazar_host_default_resource_properties }}
 {% endif %}
 
 {% if enable_zun | bool %}
 [device]
-enable_polling_monitor = true
+enable_polling_monitor = {{ blazar_zun_polling_monitor}}
 {% endif %}
 
 [virtual:floatingip]
 billrate = {{ blazar_floatingip_billrate }}
-enable_polling_monitor = true
-dry_polling_monitor = true
+enable_polling_monitor = {{ blazar_fip_polling_monitor}}
+enable_polling_monitor_dry_run = {{ blazar_fip_polling_monitor_dry_run }}
 
 [network]
 retry_allocation_without_defaults = {{ blazar_network_retry_without_default_resources | bool }}


### PR DESCRIPTION
- This is to enable the floating ip polling to clean up the resources in an errored or deleted lease
- * Setting the flag `enable_polling_monitor` to False then blazar does not periodically invoke the resource (FIP) monitor plugin to heal/clean the failed resources - PR for [FIP clean up](https://github.com/ChameleonCloud/blazar/pull/93)
- * When this option is not set, the monitor fails with following error - `oslo_config.cfg.NoSuchOptError: no such option enable_notification_monitor in group [virtual:floatingip]`

- Add config opt to blazar monitor to enable dry run
-  * Setting the flag `dry_polling_monitor` to True is to warn a failed/needs-fixing resource without attempting to fix it, to make sure that the fix is reliable and the monitor is actually picking up the right resource that needs fixing and the right fix is chosen

