### PR TITLE
This is to enable the network polling to clean up the resources

### DIFF
--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -80,6 +80,8 @@ blazar_physical_polling_monitor: true
 blazar_physical_polling_monitor_dry_run: true
 blazar_fip_polling_monitor: true
 blazar_fip_polling_monitor_dry_run: true
+blazar_network_polling_monitor: true
+blazar_network_polling_monitor_dry_run: true
 
 # Cinder
 enable_cinder: no

--- a/kolla/node_custom_config/blazar.conf
+++ b/kolla/node_custom_config/blazar.conf
@@ -65,6 +65,8 @@ enable_polling_monitor_dry_run = {{ blazar_fip_polling_monitor_dry_run }}
 [network]
 retry_allocation_without_defaults = {{ blazar_network_retry_without_default_resources | bool }}
 default_resource_properties = {{ blazar_network_default_resource_properties }}
+enable_polling_monitor = {{ blazar_network_polling_monitor}}
+enable_polling_monitor_dry_run = {{ blazar_network_polling_monitor_dry_run }}
 
 [api]
 allocation_extras = {{ blazar_api_allocation_extras }}


### PR DESCRIPTION
Setting the flag enable_polling_monitor to False then blazar does not periodically invoke the network monitor plugin to heal/clean the failed resources

When this option is not set, the monitor fails with following error - oslo_config.cfg.NoSuchOptError: no such option enable_notification_monitor in group

Add config opt to blazar monitor to enable dry run

Setting the flag dry_polling_monitor to True is to warn a failed/needs-fixing resource without attempting to fix it, to make sure that the fix is reliable and the monitor is actually picking up the right resource that needs fixing and the right fix is chosen