### PR TITLE
enable config_drive by default

### DIFF
--- a/kolla/node_custom_config/ironic.conf
+++ b/kolla/node_custom_config/ironic.conf
@@ -22,6 +22,10 @@ enabled_management_interfaces = ipmitool,noop
 enabled_inspect_interfaces = no-inspect,inspector
 default_inspect_interface = inspector
 
+# force instances to have a config_drive added, necessary for cloud-init networking
+# see https://docs.openstack.org/ironic/xena/install/configdrive.html
+force_config_drive=True
+
 [console]
 port_range = 40000:50000
 

--- a/kolla/node_custom_config/ironic.conf
+++ b/kolla/node_custom_config/ironic.conf
@@ -22,10 +22,6 @@ enabled_management_interfaces = ipmitool,noop
 enabled_inspect_interfaces = no-inspect,inspector
 default_inspect_interface = inspector
 
-# force instances to have a config_drive added, necessary for cloud-init networking
-# see https://docs.openstack.org/ironic/xena/install/configdrive.html
-force_config_drive=True
-
 [console]
 port_range = 40000:50000
 

--- a/kolla/node_custom_config/nova.conf
+++ b/kolla/node_custom_config/nova.conf
@@ -5,6 +5,10 @@ vif_plugging_is_fatal = false
 vif_plugging_timeout = 0
 max_concurrent_builds = 0
 
+# force instances to have a config_drive added, necessary for cloud-init networking
+# see https://docs.openstack.org/ironic/xena/install/configdrive.html
+force_config_drive=True
+
 [compute]
 # https://docs.openstack.org/ironic/train/install/configure-compute.html
 # > This option will cause nova-compute to set itself to a disabled state


### PR DESCRIPTION
enable the config_drive data source by default.

When enabled, this inject cloud-init metadata into an extra 64mb partition at the end of the boot disk.
Cloud-init (>v0.7.5) can automatically detect this config partition, and use it for pre-networking configuration when the network metadata endpoint is not yet available.

Specifically, this enables neutron network configuration to be dynamically sent on instance boot, letting users configure multiple interfaces, static ips, and more, rather than relying on DHCP on all interfaces.