### PR TITLE
added nvidia runtime environment variables to zun.conf

### DIFF
--- a/kolla/node_custom_config/zun.conf
+++ b/kolla/node_custom_config/zun.conf
@@ -34,6 +34,9 @@ allow_without_reservation = False
 
 {% if enable_zun_compute_k8s | bool %}
 [k8s]
+nvidia_require_jetpack = csv-mounts=all
+nvidia_visible_devices = all
+nvidia_driver_capabilities = all
 {% if enable_neutron | bool %}
 neutron_network = caliconet
 {% endif %}


### PR DESCRIPTION
Added nvidia runtime environment variables to zun.conf. These are necessary to ensure they are injected into containers that start with runtime nvidia on zun. 

Default Specification:

nvidia_require_jetpack= "csv-mounts=all"
 - this variable instructs the host to mount all the libraries mentioned above
 - ref: https://gitlab.com/nvidia/container-toolkit/container-toolkit/-/issues/11
nvidia_visible_devices= all
 - exposes all GPU devices on the host machine to the user container
 - ref: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html#gpu-enumeration
nvidia_driver_capabilities= all
 - allows all Nvidia GPU driver modules to be used by the user container
 - ref: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/1.10.0/user-guide.html#driver-capabilities