### PR TITLE
Removed Pull secret and updated k3s version

### DIFF
--- a/roles/k3s/defaults/main.yml
+++ b/roles/k3s/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-k3s_version: v1.22.5+k3s1
+k3s_version: v1.23.17+k3s1
 k3s_port: 6443
 k3s_server_location: /var/lib/rancher/k3s
 k3s_conf_location: /etc/rancher/k3s

--- a/roles/k3s/templates/calico-custom-resources.yaml.j2
+++ b/roles/k3s/templates/calico-custom-resources.yaml.j2
@@ -29,11 +29,6 @@ spec:
     # which adds a 20-byte overhead. The underlying Wireguard interface has an MTU of
     # 1420 configured, so we subtract 20 to get 1400.
     mtu: 1400
-  # TODO(jason): remove this when we have a pull-through cache deployed
-  # Pull control plane images for Calico from our private registry to avoid rate limits.
-  imagePullSecrets:
-    - name: chi-readonly-secret
-      registry: docker.chameleoncloud.org/
 
 ---
 
@@ -44,4 +39,3 @@ kind: APIServer
 metadata:
   name: default
 spec: {}
-


### PR DESCRIPTION
The Pull secret used to pull calico installation images is no longer necessary as we do not have anymore limits on pulls. Furthermore I updated the k3s version in the playbook to 1.23.17-- the version currently used in prod.