### PR TITLE
add flag for blazar nova prefilter workaround

### DIFF
--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -83,6 +83,10 @@ blazar_fip_polling_monitor_dry_run: true
 blazar_network_polling_monitor: true
 blazar_network_polling_monitor_dry_run: true
 
+# enable to use https://github.com/ChameleonCloud/nova/pull/9
+# workaround for https://bugs.launchpad.net/nova/+bug/1542491
+use_blazar_prefilter: false
+
 # Cinder
 enable_cinder: no
 
@@ -109,8 +113,8 @@ glance_allow_anonymous_access: no
 hammers_openstack_user: "{{ keystone_admin_user }}"
 hammers_openstack_password: "{{ keystone_admin_password }}"
 hammers_openstack_project_name: "{{ keystone_admin_project }}"
-hammer_lease_stacking_sender_email: ""
-hammer_lease_stacking_manager_email: ""
+hammer_lease_stacking_sender_email: "noreply@chameleoncloud.org"
+hammer_lease_stacking_manager_email: "mtrichardson@uchicago.edu"
 
 # HAProxy
 enable_haproxy: yes

--- a/kolla/node_custom_config/nova.conf
+++ b/kolla/node_custom_config/nova.conf
@@ -28,7 +28,8 @@ workers = 10
 [filter_scheduler]
 # Override default filters (just remove filters not relevant to baremetal-only)
 # default: AvailabilityZoneFilter,ComputeFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter,BlazarFilter
-enabled_filters = ComputeFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,BlazarFilter
+enabled_filters = ComputeFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter{% if not use_blazar_prefilter | bool %},BlazarFilter{% endif %}
+
 # https://docs.openstack.org/ironic/train/install/configure-compute.html
 # > Enables querying of individual hosts for instance information.
 #   Not possible for bare metal nodes, so set it to False.
@@ -78,6 +79,11 @@ max_attempts = 50
 # > The recommended value of 2 minutes matches how often the Compute
 #   service polls the Bare Metal service for node information.
 discover_hosts_in_cells_interval = 120
+
+{% if use_blazar_prefilter | bool %}
+blazar_reservation_required = True
+use_blazar_reservation_prefilter = True
+{% endif %}
 
 [serial_console]
 base_url = wss://{{ kolla_external_fqdn }}:{{ nova_serialproxy_port }}/


### PR DESCRIPTION
if `use_blazar_prefilter` is set to true, generate nova config that will disable the blazar-nova filter, and enable our custom prefilter, added to nova in https://github.com/ChameleonCloud/nova/pull/11

Workaround for https://bugs.launchpad.net/nova/+bug/1542491

Please ensure that your nova-scheduler container has this commit before enabling the flag.
https://github.com/ChameleonCloud/nova/commit/7f9058bb7000fbd9f3d226009f388cc7ce315902