### PR TITLE
Added a shell command to apply calico global netword policies

### DIFF
--- a/roles/k3s/tasks/config-calico.yml
+++ b/roles/k3s/tasks/config-calico.yml
@@ -56,9 +56,7 @@
 
 - name: Apply Calico global network policies
   delegate_to: "{{ groups['deployment'][0] }}"
-  kubernetes.core.k8s:
-    state: present
-    src: calico-global-networkpolicy-{{ item }}.yaml
+  shell: kubectl calico create --filename="{{ role_path }}/files/calico-global-networkpolicy-{{ item }}.yaml"
   loop:
     - default-deny
     - allow-ping


### PR DESCRIPTION
In their new v3 api, calico started only allowing global network policies to apply through their [own api (kubectl calico)](https://github.com/projectcalico/calico/issues/2918).

This PR is to update the config calico ansible task to apply these policies using kubectl calico instead of kubectl.