### PR TITLE
Added conf option to scope wg hub to right netns

### DIFF
--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -257,6 +257,7 @@ neutron_dev_plugins:
 
 # minimal config for neutron wireguard agent
 neutron_wireguard_hub_endpoint: "{{ kolla_external_vip_address }}"
+create_hub_in_root_netns: "{{ create_hub_in_root_netns }}"
 
 # Nova
 enable_nova: yes

--- a/kolla/node_custom_config/neutron/ml2_conf.ini
+++ b/kolla/node_custom_config/neutron/ml2_conf.ini
@@ -73,4 +73,5 @@ key_file = /etc/neutron/ssh/id_{{ switch.name }}
 {% if enable_neutron_wireguard | bool %}
 [wireguard]
 endpoint = {{ neutron_wireguard_hub_endpoint }}
+create_hub_in_root_netns = {{ create_hub_in_root_netns }}
 {% endif %}

--- a/kolla/node_custom_config/neutron/ml2_conf.ini
+++ b/kolla/node_custom_config/neutron/ml2_conf.ini
@@ -73,5 +73,5 @@ key_file = /etc/neutron/ssh/id_{{ switch.name }}
 {% if enable_neutron_wireguard | bool %}
 [wireguard]
 endpoint = {{ neutron_wireguard_hub_endpoint }}
-create_hub_in_root_netns = {{ create_hub_in_root_netns }}
+create_hub_in_root_netns = {{ neutron_wireguard_create_hub_in_root_netns }}
 {% endif %}


### PR DESCRIPTION
This change is to add the 'create_hub_in_root_netns' boolean option designed to scope the wireguard hub creation to the root network namespace if set to True. To set, add the option to the site's defaults.