### PR TITLE
New Task to create tunelo-calico network/subnet

### DIFF
--- a/roles/k3s/defaults/main.yml
+++ b/roles/k3s/defaults/main.yml
@@ -9,6 +9,7 @@ k3s_extra_server_args: ""
 
 k3s_dry_run: no
 
+k3s_tunelo_cidr: "10.0.3.0/24"
 k3s_cluster_cidr: "192.168.64.0/18"
 k3s_cluster_node_blocksize: 28
 

--- a/roles/k3s/tasks/config-neutron.yml
+++ b/roles/k3s/tasks/config-neutron.yml
@@ -52,6 +52,11 @@
 # FIXME(jason): this doesn't actually add the subnet to the router!
 # When we have updated to a later Ansible we can potentially fetch the router's
 # interfaces with routers_info and then merge this interface into the list?
+# Update (Soufiane June 25 2024) This still does not add the subnet to the router
+# two extra manual steps have to be performed after the succesful execution of this task
+# 1. Add the caliconet-subnet as an internal interface to the admin router
+# 2. Add an external gateway to the public network
+# Both of the above are pre-requisites to the proper functioning of floating ips to containers
 - name: Fetch existing NAT router
   kolla_toolbox:
     module_name: os_router

--- a/roles/k3s/tasks/config-neutron.yml
+++ b/roles/k3s/tasks/config-neutron.yml
@@ -23,6 +23,28 @@
       enable_dhcp: no
   become: yes
 
+- name: Create tunelo-calico network
+  kolla_toolbox:
+      module_name: os_network
+      module_args:
+        auth: "{{ openstack_auth }}"
+        name: tunelo-calico
+        provider_network_type: flat
+        provider_physical_network: tunelo
+        shared: false
+  become: yes
+
+- name: Create tunelo-calico subnet
+  kolla_toolbox:
+      module_name: os_subnet
+      module_args:
+        auth: "{{ openstack_auth }}"
+        network_name: tunelo-calico
+        name: tunelo-calico-subnet
+        cidr: "{{ k3s_tunelo_cidr }}"
+        enable_dhcp: yes
+  become: yes
+
 # FIXME(jason): this doesn't actually add the subnet to the router!
 # When we have updated to a later Ansible we can potentially fetch the router's
 # interfaces with routers_info and then merge this interface into the list?

--- a/roles/k3s/tasks/config-neutron.yml
+++ b/roles/k3s/tasks/config-neutron.yml
@@ -4,6 +4,7 @@
     module_name: os_network
     module_args:
       auth: "{{ openstack_auth }}"
+      project: "{{ keystone_admin_project }}"
       name: caliconet
       provider_network_type: flat
       provider_physical_network: calico
@@ -17,6 +18,7 @@
     module_name: os_subnet
     module_args:
       auth: "{{ openstack_auth }}"
+      project: "{{ keystone_admin_project }}"
       network_name: caliconet
       name: caliconet-subnet
       cidr: "{{ k3s_cluster_cidr }}"
@@ -28,6 +30,7 @@
       module_name: os_network
       module_args:
         auth: "{{ openstack_auth }}"
+        project: "{{ keystone_admin_project }}"
         name: tunelo-calico
         provider_network_type: flat
         provider_physical_network: tunelo
@@ -39,6 +42,7 @@
       module_name: os_subnet
       module_args:
         auth: "{{ openstack_auth }}"
+        project: "{{ keystone_admin_project }}"
         network_name: tunelo-calico
         name: tunelo-calico-subnet
         cidr: "{{ k3s_tunelo_cidr }}"
@@ -53,6 +57,7 @@
     module_name: os_router
     module_args:
       auth: "{{ openstack_auth }}"
+      project: "{{ keystone_admin_project }}"
       name: sharednet-router
       # interfaces:
       #   - caliconet-subnet
@@ -71,3 +76,4 @@
     neutron_router_id: "{{ calico_router.router.id }}"
   when:
     - k3s_enable_calico | bool
+  become: yes


### PR DESCRIPTION
Added a task in the k3s playbook to create the tunelo-calico network and the tunelo-calico subnet that are both necessary for the management of hub and spoke ports and the proper functioning of tunelo.