### PR TITLE
use stdout_callback to make ansible errors human readable

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -4,6 +4,9 @@
 roles_path = ./roles:./galaxy.ansible.com/ansible_roles
 collections_path = ./roles:./galaxy.ansible.com/ansible_collections
 
+# minimal, debug, yaml
+stdout_callback = yaml
+
 [inventory]
 # Ensure we fail if the inventory is malformed; this is important
 # for automation, so it does not proceed on failures.


### PR DESCRIPTION
Ansible's stdout defaults to a very dense, minimal format that is not particularly readoable. (e.g. giant blob of multiline json)

As of ansible 2.5, a human readable callback plugin (`yaml`) is built-in, and can be specified in ansible.cfg via `stdout_callback = yaml`.

Potential other options are `unixy`, `dense`, or `debug`. A full list can be found here: https://docs.ansible.com/ansible/latest/collections/callback_index_stdout.html

For more examples, see this blog post:
https://www.jeffgeerling.com/blog/2018/use-ansibles-yaml-callback-plugin-better-cli-experience