### PR TITLE
backport cleanup/fixes from antelope upgrade work

### DIFF
--- a/cc-ansible
+++ b/cc-ansible
@@ -264,7 +264,7 @@ if [[ -f "$CC_ANSIBLE_ENV" ]]; then
 fi
 
 find_kolla_ansible_base_dir () {
-  kolla_direct_url="$(find ${VIRTUAL_ENV}/lib/python*/site-packages/  -wholename '*kolla_ansible*.dist-info/direct_url.json' -print -quit 1> /dev/null 2>&1)"
+  kolla_direct_url="$(find ${VIRTUAL_ENV}/lib/  -wholename '*kolla_ansible*.dist-info/direct_url.json' -print -quit)"
   if test -n "${kolla_direct_url}"; then
       # Editable install in local path
       direct_url="$(yq eval '.url' ${kolla_direct_url})"

--- a/kolla/node_custom_config/horizon/custom_local_settings
+++ b/kolla/node_custom_config/horizon/custom_local_settings
@@ -83,23 +83,6 @@ OPENSTACK_BLAZAR_HOST_RESERVATION = {
   'enabled': {{ enable_nova | bool }},
   'url_format': '{{ blazar_host_url_format }}',
 }
-# Used for Blazar dashboard, which needs to pull data from the MySQL database
-# directly at the moment.
-DATABASES = {
-  'default': {},
-{% for conf in horizon_regions %}
-{% if conf.blazar_database_host is defined %}
-  'blazar-{{ conf.region_name }}': {
-    'ENGINE': 'django.db.backends.mysql',
-    'NAME': '{{ conf.blazar_database_name }}',
-    'HOST': '{{ conf.blazar_database_host }}',
-    'PORT': '{{ conf.blazar_database_port }}',
-    'USER': '{{ conf.blazar_database_user }}',
-    'PASSWORD': '{{ conf.blazar_database_password }}',
-  },
-{% endif %}
-{% endfor %}
-}
 {% endif %}
 
 # Add Chameleon theme and the default theme (which it inherits from), but

--- a/kolla/node_custom_config/horizon/custom_local_settings
+++ b/kolla/node_custom_config/horizon/custom_local_settings
@@ -147,17 +147,6 @@ LAUNCH_INSTANCE_DEFAULTS = {
     'create_volume': False,
 }
 
-# [2020-02-05 jason]
-# TODO: solve the root problem here and re-enable this extension.
-# Turn off SimpleTenantUsage extension, which has caused severe performance
-# penalties in our version of Horizon. This makes the little table on the
-# main dashboard page, which shows a list of recent instances, not show up.
-# The API calls to Nova to populate this UI were going through an endless loop,
-# clogging up server resources.
-OPENSTACK_NOVA_EXTENSIONS_BLACKLIST = [
-    'SimpleTenantUsage',
-]
-
 # The OPENSTACK_IMAGE_BACKEND settings can be used to customize features
 # in the OpenStack Dashboard related to the Image service, such as the list
 # of supported image formats.


### PR DESCRIPTION
This PR collects various cleanups and fixes identified during the antelope upgrade work, in order to separate them from those changes actually necessary for the version upgrade.

These mostly consist of changes needed in old versions that were unnecessarily carried forward to xena.