### PR TITLE
add encrypt_file/decrypt_file methods

### DIFF
--- a/cc-ansible
+++ b/cc-ansible
@@ -36,7 +36,7 @@ while [[ $# -gt 0 ]]; do
       # Add proper flag support for --check as an option for dry-runs
       export EXTRA_OPTS="${EXTRA_OPTS:-} --check"
       ;;
-    decrypt_passwords|edit_passwords|help|install_deps|init|view_passwords)
+    decrypt_passwords|edit_passwords|help|install_deps|init|view_passwords|encrypt_file|decrypt_file)
       # Special subcommand!
       command="$key"
       ;;
@@ -137,6 +137,18 @@ init() {
   echo
 }
 
+encrypt_file() {
+  ansible-vault encrypt \
+    --vault-password-file "$CC_ANSIBLE_VAULT_PASSWORD" \
+    ${POSARGS[@]}
+}
+
+decrypt_file() {
+  ansible-vault decrypt \
+    --vault-password-file "$CC_ANSIBLE_VAULT_PASSWORD" \
+    ${POSARGS[@]}
+}
+
 edit_passwords() {
   local tmpfile
   local venv_bin_path="${VIRTUALENV}/bin"
@@ -213,6 +225,10 @@ Examples:
 
   # Update the passwords file for the environment
   cc-ansible edit_passwords
+
+  # use ansible-vault to encrypt or decrypt a file
+  cc-ansible encrypt_file path/to/file
+  cc-ansible decrypt_file path/to/file
 USAGE
   exit 1
 }


### PR DESCRIPTION
Kolla ansible supports automatic decryption of vault-encrypted files in site-config.
This is very useful for things like ceph authentication tokens, certificates, and so on.

Note: This CANNOT be used for the SSH key for ansible to connect to a remote host.
          See https://github.com/ansible/ansible/issues/22382

Add cc-ansible wrappers for `vault encrypt` and `vault decrypt` to make this easy.
