### PR TITLE
move ansible_python_interpereter to all.yaml so it can be overridden

### DIFF
--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -17,7 +17,7 @@ admin_openrc_directory: "{{ site_config_dir }}"
 # virtualenv specifies the path to the kolla virtualenv, while ansible_python_interpreter must be set explicitly
 # since it cannot be templated. This is overridden during bootstrap by cc-ansible.
 virtualenv: /etc/ansible/venv
-ansible_python_interpreter: /etc/ansible/venv/bin/python
+# ansible_python_interpreter: /etc/ansible/venv/bin/python
 
 chameleon_portal_url: https://www.chameleoncloud.org
 chameleon_reference_api_url: https://api.chameleoncloud.org

--- a/site-config.example/inventory/group_vars/all.yaml
+++ b/site-config.example/inventory/group_vars/all.yaml
@@ -1,0 +1,2 @@
+---
+ansible_python_interpreter: /etc/ansible/venv/bin/python


### PR DESCRIPTION
This is going to need an upgrade note, since it will require modification of the site-config or things will break.