### PR TITLE
inspector: parse lldp data, accelerators, boot_mode

### DIFF
--- a/kolla/node_custom_config/ironic-inspector.conf
+++ b/kolla/node_custom_config/ironic-inspector.conf
@@ -15,14 +15,23 @@ keep_ports = present
 # Whether to overwrite existing values in node database. Disable this
 # option to make introspection a non-destructive operation. (boolean
 # value)
-overwrite_existing = False
+overwrite_existing = true
 
 # Whether to update the pxe_enabled value according to the
 # introspection data. This option has no effect if
 # [processing]overwrite_existing is set to False (boolean value)
-#update_pxe_enabled = true
+update_pxe_enabled = true
 
 # The storage backend for storing introspection data. Possible values
 # are: 'none', 'database' and 'swift'. If set to 'none', introspection
 # data will not be stored. (string value)
 store_data = database
+
+# https://docs.openstack.org/ironic-inspector/2023.1/configuration/ironic-inspector.html#processing.processing_hooks
+# for choices, see https://docs.openstack.org/ironic-inspector/2023.1/user/usage.html#plugins
+# data is source via: https://docs.openstack.org/ironic-python-agent/2023.1/admin/how_it_works.html#inspection-data
+processing_hooks = $default_processing_hooks,extra_hardware,lldp_basic,accelerators
+
+[capabilities]
+# Whether to store the boot mode (BIOS or UEFI).
+boot_mode = true


### PR DESCRIPTION
configure ironic-inspector to parse more information out of the collected data, in particular decoding lldp data for switchports, and mapping pci ids to accelerators.

Additionally, allow inspector to update the value of "boot_mode" and "pxe_enabled" capabilities on the node and node's ports.