### PR TITLE
update ironic kernel append params

### DIFF
--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -183,7 +183,7 @@ ironic_inspection_network: "{{ ironic_provisioning_network }}"
 ironic_image_cache_size: 20480 # MB
 ironic_console_serial_speed: 115200n8
 encoded_ironic_pxe_root_password: "{{ ironic_pxe_root_password | password_hash('md5') |  regex_replace( '(\\$)', '$\\1') }}"
-ironic_pxe_append_params: nofb nomodeset vga=normal console=tty0 console=ttyS0,{{ ironic_console_serial_speed }} systemd.journald.forward_to_console=yes rootpwd="{{ encoded_ironic_pxe_root_password }}"
+ironic_kernel_append_params: nofb nomodeset vga=normal console=tty0 console=ttyS0,{{ ironic_console_serial_speed }} systemd.journald.forward_to_console=yes rootpwd="{{ encoded_ironic_pxe_root_password }}"
 
 # settings for ironic inspector
 

--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -183,7 +183,7 @@ ironic_inspection_network: "{{ ironic_provisioning_network }}"
 ironic_image_cache_size: 20480 # MB
 ironic_console_serial_speed: 115200n8
 encoded_ironic_pxe_root_password: "{{ ironic_pxe_root_password | password_hash('md5') |  regex_replace( '(\\$)', '$\\1') }}"
-ironic_kernel_append_params: nofb nomodeset vga=normal console=tty0 console=ttyS0,{{ ironic_console_serial_speed }} systemd.journald.forward_to_console=yes rootpwd="{{ encoded_ironic_pxe_root_password }}"
+ironic_kernel_append_params: nofb vga=normal console=tty0 console=ttyS0,{{ ironic_console_serial_speed }} rootpwd="{{ encoded_ironic_pxe_root_password }}"
 
 # settings for ironic inspector
 

--- a/kolla/node_custom_config/ironic.conf
+++ b/kolla/node_custom_config/ironic.conf
@@ -81,7 +81,7 @@ location = /opt/stack/node_metrics
 {% endif %}
 
 [pxe]
-pxe_append_params = "{{ ironic_pxe_append_params }}"
+kernel_append_params = "{{ ironic_kernel_append_params }}"
 image_cache_size = "{{ ironic_image_cache_size }}"
 ipxe_bootfile_name_by_arch = aarch64:aarch64/snponly.efi
 # [ech] Still needed for ARM? pxe_bootfile_name_by_arch = aarch64:shimaa64.efi


### PR DESCRIPTION
this PR has a couple of changes:

1. in ironic, `pxe_append_params` is deprecated, so we need to replace it with `kernel_append_params`
2. the `nodemodeset` and `systemd.journald.forward_to_console` options can both cause blocking and performance issues, so they have been removed.

Links to issues:
https://github.com/openstack/ironic/blob/e01522cd4ca02897bbecc4190ce128c5a344fd9f/releasenotes/notes/remove-nomodset-7a352a9519c1045b.yaml#L5