### PR TITLE
Wip/update horizon antelope

### DIFF
--- a/kolla/node_custom_config/horizon/custom_local_settings
+++ b/kolla/node_custom_config/horizon/custom_local_settings
@@ -152,6 +152,11 @@ LAUNCH_INSTANCE_DEFAULTS = {
     'disable_volume': True,
     'disable_volume_snapshot': True,
     'create_volume': False,
+    'enable_metadata': False,
+    'enable_net_ports': True,
+    'enable_secgroups': False,
+    'enable_servergroups': False,
+    'default_flavor_name': 'baremetal',
 }
 
 # The OPENSTACK_IMAGE_BACKEND settings can be used to customize features
@@ -186,3 +191,6 @@ OPENSTACK_MANILA_FEATURES = {
 # necessary to embed serial console in iframe
 # Django3.0 changed the default from 'SAMEORIGIN' to 'DENY'
 X_FRAME_OPTIONS = 'SAMEORIGIN'
+
+# disable usage report on overview page
+OPENSTACK_USE_SIMPLE_TENANT_USAGE = False

--- a/kolla/node_custom_config/horizon/custom_local_settings
+++ b/kolla/node_custom_config/horizon/custom_local_settings
@@ -71,6 +71,11 @@ USER_MENU_LINKS = [
     'url': 'horizon:project:api_access:openrc',
     'external': False,
   },
+  {
+    'name': _('OpenStack clouds.yaml File'),
+    'icon_classes': ['fa-download', ],
+    'url': 'horizon:project:api_access:clouds.yaml',
+  },
 ]
 
 {% if enable_blazar | bool %}


### PR DESCRIPTION
By default, now disables the "usage summary" on the overview page, as well as the instance launch page's "metadata", "security_groups", and "server_groups" tabs.

Additionally the clouds.yaml file is made visible in the user's account drop-down menu, not just openrc.sh.
<img width="223" alt="image" src="https://github.com/user-attachments/assets/75b79ca6-1add-46eb-afe3-6e33edecbe96">

If these changes are deployed with an older horizon container that does not yet have the toggles for security_group and server_group visiblity, nothing will happen, so it can be deployed in either order.

(see this PR for more info https://github.com/ChameleonCloud/horizon/pull/27)