### PR TITLE
Add options for blazar email config in blazar.conf

### DIFF
--- a/kolla/node_custom_config/blazar.conf
+++ b/kolla/node_custom_config/blazar.conf
@@ -46,6 +46,18 @@ heartbeat_in_pthread = false
 [physical:host]
 before_end = email
 email_relay = {{ blazar_email_relay }}
+{% if blazar_email_port is defined %}
+email_port = {{ blazar_email_port }}
+{% endif %}
+{% if blazar_email_ssl is defined %}
+email_ssl = {{ blazar_email_ssl }}
+{% endif %}
+{% if blazar_email_user is defined %}
+email_user = {{ blazar_email_user }}
+{% endif %}
+{% if blazar_email_password is defined %}
+email_password = {{ blazar_email_password }}
+{% endif %}
 enable_polling_monitor = {{ blazar_physical_polling_monitor}}
 enable_polling_monitor_dry_run = {{ blazar_physical_polling_monitor_dry_run }}
 retry_allocation_without_defaults = {{ blazar_host_retry_without_default_resources | bool }}


### PR DESCRIPTION
Adds the options from https://github.com/ChameleonCloud/kolla-containers/pull/43 to `blazar.conf`