### PR TITLE
setting to wipe all disks before deployment

### DIFF
--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -184,6 +184,7 @@ ironic_image_cache_size: 20480 # MB
 ironic_console_serial_speed: 115200n8
 encoded_ironic_pxe_root_password: "{{ ironic_pxe_root_password | password_hash('md5') |  regex_replace( '(\\$)', '$\\1') }}"
 ironic_kernel_append_params: nofb vga=normal console=tty0 console=ttyS0,{{ ironic_console_serial_speed }} rootpwd="{{ encoded_ironic_pxe_root_password }}"
+ironic_erase_devices_metadata_during_deploy: false
 
 # settings for ironic inspector
 

--- a/kolla/node_custom_config/ironic.conf
+++ b/kolla/node_custom_config/ironic.conf
@@ -52,6 +52,10 @@ enable_for_conductor = False
 [deploy]
 default_boot_option = local
 
+{% if ironic_erase_devices_metadata_during_deploy | bool %}
+erase_devices_metadata_during_deploy = True
+{% endif %}
+
 [inspector]
 require_managed_boot = True
 # passed to ironic-python-agent, see :


### PR DESCRIPTION
allow setting `ironic_erase_devices_metadata_during_deploy` to delete metadata from all disks during deploy, prior to writing a new image. This removes unreliability from leftover data, without requiring an additional reboot for automated cleaning.