### PR TITLE
ensure ceph rgw port defaults to 7480

### DIFF
--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -315,7 +315,7 @@ redfish_monitor_openstack_password: "{{ keystone_admin_password }}"
 redfish_monitor_openstack_project_name: "{{ keystone_admin_project }}"
 
 # Swift
-rgw_port: 7480 # Override non-standard KA default of 6780
+ceph_rgw_port: 7480 # Override non-standard KA default of 6780
 # Disable complete rgw compatibility for now. If Ceph has these options set,
 # it is considered "compatible":
 #   rgw_swift_url_prefix = "/"


### PR DESCRIPTION
our ceph rgws listen on port 7480, and we need to configure the keystone endpoint to match. We had been doing this in the chi-in-a-box defaults via `rgw_port`, but the kolla syntax has changed to `ceph_rgw_port` instead.

A separate question is should we be overriding this at all anymore, but that's out of scope.