### PR TITLE
reduce memory usage

### DIFF
--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -34,7 +34,6 @@ enable_mariadb: yes
 enable_chrony: yes
 enable_fluentd: yes
 enable_memcached: yes
-memcached_max_memory: 2048
 enable_rabbitmq: yes
 
 # Automatic backups

--- a/kolla/node_custom_config/galera.cnf
+++ b/kolla/node_custom_config/galera.cnf
@@ -1,0 +1,7 @@
+[mysqld]
+{% set dynamic_pool_size_mb = (hostvars[inventory_hostname].ansible_facts.memtotal_mb * 0.2) | round | int %}
+{% if dynamic_pool_size_mb < 8192 %}
+innodb_buffer_pool_size = '{{ dynamic_pool_size_mb }}M'
+{% else %}
+innodb_buffer_pool_size = '8192M'
+{% endif %}


### PR DESCRIPTION
This PR reduces memory usage by memcached and mariadb.

However, we may want to put more effort into the new default values used, and/or make it more easily configurable by the site operator.