### PR TITLE
[ironic] disable node history due to bug 2054594

### DIFF
--- a/kolla/node_custom_config/ironic.conf
+++ b/kolla/node_custom_config/ironic.conf
@@ -29,6 +29,11 @@ port_range = 40000:50000
 # We do not perform automated cleaning to improve turnaround time on a node.
 automated_clean = False
 
+# M.S. disable node history due to incompatibility with 64 character user_ids
+# see bug https://bugs.launchpad.net/ironic/+bug/2054594
+# revert when upgrading to 2024.1
+node_history = false
+
 # deploy kernel and ramdisk to use if not set on node
 {% if ironic_deploy_kernel is defined %}
 deploy_kernel = "{{ ironic_deploy_kernel }}"


### PR DESCRIPTION
Workaround for nodes getting stuck in "bad" states until restart of ironic conductor, as well as recovery from network-related errors.

LP: https://bugs.launchpad.net/ironic/+bug/2054594 ironic uses a 32 character DB column for user_id, which is too short for the 64 character ids returned by keystone with federated login

the real fix is a db migration, but that is hugely painful to try and backport from 2024.1. Instead, just diable the node_history feature, which seems to be the only thing in ironic writing 64 character IDs.

Revert after upgrading to 2024.1.