### PR TITLE
[horizon] set angular tempale cache expiry to 1d

### DIFF
--- a/kolla/node_custom_config/horizon/custom_local_settings
+++ b/kolla/node_custom_config/horizon/custom_local_settings
@@ -194,3 +194,6 @@ X_FRAME_OPTIONS = 'SAMEORIGIN'
 
 # disable usage report on overview page
 OPENSTACK_USE_SIMPLE_TENANT_USAGE = False
+
+# override 30d default for angular template caching
+NG_TEMPLATE_CACHE_AGE = 86400


### PR DESCRIPTION
when horizon starts up, it compresses angular template fragments for later speedups, and these compressed templates are later stored in the django cache, and also in browser caches.

When the cache expires (default of 30d), the django cache is cleared, and a new cache generated. The cache url is based on the hash of the contents, and so a new url will be generated at this point if the content has changed, causing clients to pull it instead of using their browser cache.

To work around serving stale data during upgrades/patches, we set this expiry to 1d (down from 30). Really, we should be ensuring that horizon re-compresses (and re-hashes) the templates before restarting, which should accomplish the same result.

Details of operation are in:
https://github.com/openstack/horizon/commit/fca46ab60ffd798fda67ea045905f7932ed1347b