### PR TITLE
add templates for central monitoring

### DIFF
--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -331,13 +331,18 @@ enable_swift: no
 enable_swift_rgw: no
 
 # Monitoring
-# TODO: install ES curator
-enable_central_logging: yes
+enable_central_logging: no
 es_heap_size: 8G
 # Includes log4j safeguard: https://github.com/elastic/elasticsearch/issues/81618
 es_java_opts: "-Xms{{ es_heap_size }} -Xmx{{ es_heap_size }} -Dlog4j2.formatMsgNoLookups=true"
 es_enable_painless_regex: no
 enable_grafana: no
+
+loki_url: "https://logs.chameleoncloud.org"
+prometheus_remote_write_url: "https://metrics.chameleoncloud.org/api/v1/push"
+prometheus_remote_write_username: "{{ keystone_idp_client_id }}"
+upload_logs_chameleon: false
+upload_metrics_chameleon: false
 
 # External Ceph
 enable_ceph: no

--- a/kolla/node_custom_config/fluentd/output/50-loki.conf
+++ b/kolla/node_custom_config/fluentd/output/50-loki.conf
@@ -1,0 +1,31 @@
+{% if upload_logs_chameleon | bool %}
+<match **>
+  @type loki
+  url "{{ loki_url }}"
+  username "{{ prometheus_remote_write_username }}"
+  password "{{ prometheus_remote_write_password }}"
+  extra_labels {
+    "kolla_external_fqdn": "{{ kolla_external_fqdn }}",
+    "keystone_idp_client_id": "{{ keystone_idp_client_id }}",
+    "openstack_region_name": "{{ openstack_region_name }}",
+    "chameleon_site_name": "{{ chameleon_site_name }}"
+  }
+  <buffer>
+    flush_interval 10s
+    flush_at_shutdown true
+  </buffer>
+
+  <label>
+    Hostname
+  </label>
+  <label>
+    Logger
+  </label>
+  <label>
+    programname
+  </label>
+  <label>
+    level log_level
+  </label>
+</match>
+{% endif %}

--- a/kolla/node_custom_config/prometheus/prometheus.yml.d/10-central-metrics.yml
+++ b/kolla/node_custom_config/prometheus/prometheus.yml.d/10-central-metrics.yml
@@ -1,0 +1,15 @@
+---
+{% if upload_metrics_chameleon | bool %}
+remote_write:
+  - url: "{{ prometheus_remote_write_url }}"
+    basic_auth:
+      username: "{{ prometheus_remote_write_username }}"
+      password: "{{ prometheus_remote_write_password }}"
+{% endif %}
+
+global:
+  external_labels:
+    kolla_external_fqdn: "{{ kolla_external_fqdn }}"
+    keystone_idp_client_id: "{{ keystone_idp_client_id }}"
+    openstack_region_name: "{{ openstack_region_name }}"
+    chameleon_site_name: "{{ chameleon_site_name }}"


### PR DESCRIPTION
This takes our current, ad-hoc configuration for sending metrics+logs to our central infra, and finally merges it into chi-in-a-box.

Two new toggles are added, defaulting to false, `upload_logs_chameleon` and `upload_metrics_chameleon`.
The fluentd and prometheus template files are only populated if these are true, preventing the current behavior from changing.

This also assumes that `keystone_idp_client_id` is used as the username for each site for pushing to both loki and mimir, and that the `prometheus_remote_write_password` is used as the password for both.