### PR TITLE
add a role for hammers_v2 systemd units/timers

### DIFF
--- a/roles/hammers/defaults/main.yml
+++ b/roles/hammers/defaults/main.yml
@@ -70,3 +70,13 @@ hammers:
     enabled: "{{ enable_k3s | bool}}"
 
 hammers_slack_webhook: "{{ slack_api_url }}"
+
+hammers_v2_docker_image: ghcr.io/chameleoncloud/chameleon_site_tools:main
+hammers_v2:
+  floating_ip_network_reaper:
+    description: "Clean up networks for expired projects."
+    env_file: "{{ hammers_env_file }}"
+    image: "{{ hammers_v2_docker_image }}"
+    cmd: floating_ip_network_reaper --cloud envvars --grace-days 7 --dry-run
+    enabled: "{{ enable_neutron | bool }}"
+    calendar: daily

--- a/roles/hammers/handlers/main.yml
+++ b/roles/hammers/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: reload systemd
+  ansible.builtin.systemd_service:
+    daemon_reload: true

--- a/roles/hammers/tasks/install_unit.yml
+++ b/roles/hammers/tasks/install_unit.yml
@@ -1,0 +1,25 @@
+---
+- name: "set up service: {{ item.key }}"
+  vars:
+    description: "{{item.value.description | default(item.key) }}"
+    env_file: "{{item.value.env_file | default(hammers_env_file)}}"
+    image: "{{item.value.image | default(hammers_docker_image) }}"
+    cmd: "{{item.value.cmd}}"
+    calendar: "{{item.value.calendar | default(daily) }}"
+    enabled: "{{item.value.enabled}}"
+  notify:
+    - reload systemd
+  block:
+    - name: template unit file
+      template:
+        src: hammers.service.j2
+        dest: "/etc/systemd/system/{{ service_name }}.service"
+    - name: template timer file
+      template:
+        src: hammers.timer.j2
+        dest: "/etc/systemd/system/{{ service_name }}.timer"
+    - name: Set timer state
+      ansible.builtin.systemd_service:
+        name: "{{ service_name }}.timer"
+        state: "{{ timer_state }}"
+        enabled: "{{ timer_enabled }}"

--- a/roles/hammers/tasks/install_unit.yml
+++ b/roles/hammers/tasks/install_unit.yml
@@ -1,6 +1,7 @@
 ---
 - name: "set up service: {{ item.key }}"
   vars:
+    container_name: "{{ item.value.container_name | default(item.key)}}"
     description: "{{item.value.description | default(item.key) }}"
     env_file: "{{item.value.env_file | default(hammers_env_file)}}"
     image: "{{item.value.image | default(hammers_docker_image) }}"

--- a/roles/hammers/tasks/main.yml
+++ b/roles/hammers/tasks/main.yml
@@ -101,3 +101,13 @@
   loop: "{{ hammers | dict2items }}"
   loop_control:
     label: "{{ item.key }}"
+  when:
+    - item.value.enabled
+
+- name: set hammers_v2 periodic_tasks
+  include_tasks: install_unit.yml
+  vars:
+    service_name: "hammer_{{ item.key }}"
+    timer_state: "{{ 'started' if item.value.enabled else 'stopped' }}"
+    timer_enabled: "{{item.value.enabled}}"
+  loop: "{{ hammers_v2 | dict2items }}"

--- a/roles/hammers/tasks/main.yml
+++ b/roles/hammers/tasks/main.yml
@@ -7,50 +7,50 @@
     force_source: yes
 
 - name: Create config directory.
-  become: yes
+  become: true
   file:
     path: "{{ hammers_config_path }}"
     state: directory
 
 - name: Configure kubeconfig for K8s hammers
   block:
-  - name: Copy kubeconfig.yml file
-    become: yes
-    copy:
-      src: "{{ kubeconfig_path }}/kubeconfig.yml"
-      dest: "{{ hammers_kubeconfig_path }}"
-      mode: 0600
-
+    - name: Copy kubeconfig.yml file
+      become: true
+      copy:
+        src: "{{ kubeconfig_path }}/kubeconfig.yml"
+        dest: "{{ hammers_kubeconfig_path }}"
+        mode: 0600
   rescue:
     - name: Create a placeholder kubeconfig.yml
-      become: yes
+      become: true
       file:
         path: "{{ hammers_kubeconfig_path }}"
         state: touch
         mode: 0600
     - name: Add "placeholder" content to kubeconfig.yml
-      become: yes
+      become: true
       lineinfile:
         path: "{{ hammers_kubeconfig_path }}"
         line: "placeholder"
         create: yes
+  when: "{{ enable_k3s | bool }}"
 
 - name: Configure Hammers docker bash wrapper
-  become: yes
+  become: true
   template:
     src: cc-hammer.j2
     mode: a+x
     dest: /usr/local/sbin/cc-hammer
 
 - name: Configure Hammers env file
-  become: yes
+  become: true
   template:
     src: hammers.env.j2
     mode: 0600
     dest: "{{ hammers_env_file }}"
 
 - name: Configure slack webhook file
-  become: yes
+  become: true
   template:
     src: slack.json.j2
     mode: 0600
@@ -58,7 +58,7 @@
   when: hammers_slack_webhook is defined
 
 - name: Configure lease stacking config file
-  become: yes
+  become: true
   template:
     src: lease-stacking.json.j2
     mode: 0600
@@ -81,7 +81,7 @@
   delegate_to: "{{ groups['hammers'][0] }}"
 
 - name: Configure Hammers my.cnf
-  become: yes
+  become: true
   template:
     src: my.cnf.j2
     dest: "{{ hammers_config_path }}/my.cnf"
@@ -92,7 +92,7 @@
   include_role:
     name: chameleon.periodic_task
     apply:
-      become: yes
+      become: true
   vars:
     task_name: "hammer_{{ item.key }}"
     task_command: "/usr/local/sbin/cc-hammer {{ item.value.cmd }}"

--- a/roles/hammers/templates/hammers.service.j2
+++ b/roles/hammers/templates/hammers.service.j2
@@ -1,0 +1,18 @@
+# {{ ansible_managed }}
+
+[Unit]
+Description={{ description }}
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/docker run \
+    --net=host \
+    --rm \
+    --env-file {{ env_file }} \
+    -v "{{hammers_config_path}}:{{hammers_config_path}}:ro" \
+    {{ image }} \
+    {{ cmd }} 
+[Install]
+WantedBy=multi-user.target

--- a/roles/hammers/templates/hammers.service.j2
+++ b/roles/hammers/templates/hammers.service.j2
@@ -10,6 +10,8 @@ Type=oneshot
 ExecStart=/usr/bin/docker run \
     --net=host \
     --rm \
+    --name {{ container_name }} \
+    --label org.chameleoncloud.hammer={{ container_name }} \
     --env-file {{ env_file }} \
     -v "{{hammers_config_path}}:{{hammers_config_path}}:ro" \
     {{ image }} \

--- a/roles/hammers/templates/hammers.timer.j2
+++ b/roles/hammers/templates/hammers.timer.j2
@@ -1,0 +1,13 @@
+# {{ ansible_managed }}
+
+[Unit]
+Description={{ description }}
+
+[Timer]
+OnCalendar={{ calendar }}
+RandomizedDelaySec=3h
+AccuracySec=1s
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Some new logic has been added to deploy hammers_v2 based containers, and the networks+floatingip+router reaper has been added, *in dry-run mode*.

The updated role should be largely backwards compatible, in that by moving an entry from defaults/hammers to defaults/hammers_v2, the new config templating will take over, no longer calling /usr/local/sbin/cc-hammer or the periodic-tasks role.