### PR TITLE
Replace original FIP reaper with hammers_v2 version

### DIFF
--- a/roles/hammers/defaults/main.yml
+++ b/roles/hammers/defaults/main.yml
@@ -11,7 +11,7 @@ hammers:
   floating_ip_reaper:
     cmd: floatingip-reaper --grace-days 7
     calendar: daily
-    enabled: "{{ enable_neutron | bool }}"
+    enabled: false
   conflict_macs:
     cmd: conflict-macs delete
     calendar: daily

--- a/roles/hammers/defaults/main.yml
+++ b/roles/hammers/defaults/main.yml
@@ -77,6 +77,6 @@ hammers_v2:
     description: "Clean up networks for expired projects."
     env_file: "{{ hammers_env_file }}"
     image: "{{ hammers_v2_docker_image }}"
-    cmd: floating_ip_network_reaper --cloud envvars --grace-days 7 --dry-run
+    cmd: floating_ip_network_reaper --cloud envvars --grace-days 7  --clean-floatingips --clean-routers
     enabled: "{{ enable_neutron | bool }}"
     calendar: daily

--- a/roles/hammers/tasks/main.yml
+++ b/roles/hammers/tasks/main.yml
@@ -101,8 +101,6 @@
   loop: "{{ hammers | dict2items }}"
   loop_control:
     label: "{{ item.key }}"
-  when:
-    - item.value.enabled
 
 - name: set hammers_v2 periodic_tasks
   include_tasks: install_unit.yml


### PR DESCRIPTION
although there's a bug in the new "networks" cleanup, the FIP and router cleanup is ok.
This modification ensures we properly disable the old one, and enable the new one with correct flags.