### PR TITLE
add role to deploy new usage collector

### DIFF
--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -370,6 +370,7 @@ enable_osg: no
 
 # usage reporting
 enable_usage_reporting: no
+enable_usage_reporting_new: no
 
 # image tools
 enable_image_deployer: no

--- a/playbooks/chameleon_usage.yml
+++ b/playbooks/chameleon_usage.yml
@@ -3,3 +3,5 @@
   roles:
     - role: chameleon_usage
       when: enable_usage_reporting | bool
+    - role: usage_collector
+      when: enable_usage_reporting_new | bool

--- a/roles/usage_collector/defaults/main.yml
+++ b/roles/usage_collector/defaults/main.yml
@@ -19,3 +19,29 @@ usage_collector_db_uri: "mysql://{{ usage_collector_mysql_user }}:{{ usage_colle
 usage_collector_s3_endpoint: https://chi.uc.chameleoncloud.org:7480
 # usage_collector_s3_access_key_id:
 # usage_collector_secret_access_key:
+
+usage_collector_manage_mysql_grants: true
+
+usage_collector_mysql_grants:
+  - nova.compute_nodes:SELECT
+  - nova.instances:SELECT
+  - nova.instance_actions:SELECT
+  - nova.instance_actions_events:SELECT
+  - nova_api.request_specs:SELECT
+  - blazar.computehosts:SELECT
+  - blazar.computehost_allocations:SELECT
+  - blazar.reservations:SELECT
+  - blazar.instance_reservations:SELECT
+  - blazar.leases:SELECT
+  - blazar.devices:SELECT
+  - blazar.device_allocations:SELECT
+  - blazar.device_extra_capabilities:SELECT
+  - blazar.device_reservations:SELECT
+  - zun.container:SELECT
+  - zun.container_actions:SELECT
+  - zun.container_actions_events:SELECT
+  - chameleon_usage.node_usage_report_cache:SELECT
+  - chameleon_usage.node_count_cache:SELECT
+  - chameleon_usage.node_usage:SELECT
+  - chameleon_usage.node_event:SELECT
+  - chameleon_usage.node_maintenance:SELECT

--- a/roles/usage_collector/defaults/main.yml
+++ b/roles/usage_collector/defaults/main.yml
@@ -1,0 +1,21 @@
+---
+
+usage_collector_image: ghcr.io/chameleoncloud/usage-exploration
+usage_collector_tag: sha-80d51ce
+usage_collector_image_full: "{{ usage_collector_image }}:{{ usage_collector_tag }}"
+
+usage_collector_config_dir: /etc/chameleon_usage_collector
+usage_collector_timer: "*-*-* 00:00:00" # collect daily at midnight
+
+usage_collector_site_key: "{{ chameleon_site_name }}" # from defaults.yml or site-config
+usage_collector_site_name: "{{ openstack_region_name }}"
+
+usage_collector_mysql_user: cc_usage # Read only user
+#usage_collector_mysql_password:
+
+usage_collector_db_uri: "mysql://{{ usage_collector_mysql_user }}:{{ usage_collector_mysql_password }}@{{ database_address }}"
+
+# usage_collector_data_dir:  # path to save exported data. May start with s3://
+usage_collector_s3_endpoint: https://chi.uc.chameleoncloud.org:7480
+# usage_collector_s3_access_key_id:
+# usage_collector_secret_access_key:

--- a/roles/usage_collector/tasks/main.yml
+++ b/roles/usage_collector/tasks/main.yml
@@ -22,7 +22,7 @@
   when:
     - usage_collector_manage_mysql_grants | default(false) | bool
 
-- name: Ensure usage collector MySQL user exists with required grants
+- name: Apply usage collector grants
   become: true
   kolla_toolbox:
     container_engine: "{{ kolla_container_engine }}"
@@ -34,9 +34,13 @@
       name: "{{ usage_collector_mysql_user }}"
       host: "{{ usage_collector_mysql_host | default('%') }}"
       password: "{{ usage_collector_mysql_password }}"
-      priv: "{{ usage_collector_mysql_grants | join('/') }}"
+      priv: "{{ item }}"
       append_privs: true
       state: present
+  loop: "{{ usage_collector_mysql_grants }}"
+  loop_control:
+    label: "{{ item }}"
+  ignore_errors: true
   run_once: true
   delegate_to: "{{ groups['control'][0] }}"
   when:

--- a/roles/usage_collector/tasks/main.yml
+++ b/roles/usage_collector/tasks/main.yml
@@ -1,0 +1,73 @@
+---
+- name: Validate required usage_collector variables
+  assert:
+    that:
+      - usage_collector_data_dir is string
+      - usage_collector_data_dir | trim | length > 0
+      - usage_collector_mysql_password is string
+      - usage_collector_mysql_password | trim | length > 0
+      - usage_collector_s3_access_key_id is string
+      - usage_collector_s3_access_key_id | trim | length > 0
+      - usage_collector_secret_access_key is string
+      - usage_collector_secret_access_key | trim | length > 0
+    fail_msg: |
+      "Set usage_collector_data_dir, usage_collector_mysql_password, usage_collector_s3_access_key_id, and usage_collector_secret_access_key."
+
+- name: Pull Docker image
+  become: true
+  docker_image:
+    source: pull
+    name: "{{ usage_collector_image_full }}"
+    force_source: yes
+
+- name: Ensure config directory exists
+  become: true
+  file:
+    path: "{{ usage_collector_config_dir }}"
+    state: directory
+    owner: "{{ config_owner_user }}"
+    group: "{{ config_owner_group }}"
+
+- name: template site.yaml file
+  become: true
+  template:
+    src: site.yaml.j2
+    dest: "{{ usage_collector_config_dir }}/site.yaml"
+    mode: "0600"
+    owner: "{{ config_owner_user }}"
+    group: "{{ config_owner_group }}"
+
+- name: template usage-env file
+  become: true
+  template:
+    src: usage-env.j2
+    dest: "{{ usage_collector_config_dir }}/usage-env"
+    mode: "0600"
+    owner: "{{ config_owner_user }}"
+    group: "{{ config_owner_group }}"
+
+- name: Deploy usage_collector service unit
+  become: true
+  template:
+    src: usage_collector.service.j2
+    dest: /etc/systemd/system/usage_collector.service
+    mode: "0644"
+
+- name: Deploy usage_collector timer unit
+  become: true
+  template:
+    src: usage_collector.timer.j2
+    dest: /etc/systemd/system/usage_collector.timer
+    mode: "0644"
+
+- name: Reload systemd
+  become: true
+  systemd:
+    daemon_reload: yes
+
+- name: Enable and start usage_collector.timer
+  become: true
+  systemd:
+    name: usage_collector.timer
+    enabled: yes
+    state: started

--- a/roles/usage_collector/tasks/main.yml
+++ b/roles/usage_collector/tasks/main.yml
@@ -13,6 +13,35 @@
     fail_msg: |
       "Set usage_collector_data_dir, usage_collector_mysql_password, usage_collector_s3_access_key_id, and usage_collector_secret_access_key."
 
+- name: Validate grant list is not empty
+  assert:
+    that:
+      - usage_collector_mysql_grants is sequence
+      - usage_collector_mysql_grants is not string
+      - usage_collector_mysql_grants | length > 0
+  when:
+    - usage_collector_manage_mysql_grants | default(false) | bool
+
+- name: Ensure usage collector MySQL user exists with required grants
+  become: true
+  kolla_toolbox:
+    container_engine: "{{ kolla_container_engine }}"
+    module_name: mysql_user
+    module_args:
+      login_host: "{{ database_address }}"
+      login_user: "{{ database_user }}"
+      login_password: "{{ database_password }}"
+      name: "{{ usage_collector_mysql_user }}"
+      host: "{{ usage_collector_mysql_host | default('%') }}"
+      password: "{{ usage_collector_mysql_password }}"
+      priv: "{{ usage_collector_mysql_grants | join('/') }}"
+      append_privs: true
+      state: present
+  run_once: true
+  delegate_to: "{{ groups['control'][0] }}"
+  when:
+    - usage_collector_manage_mysql_grants | default(false) | bool
+
 - name: Pull Docker image
   become: true
   docker_image:

--- a/roles/usage_collector/templates/site.yaml.j2
+++ b/roles/usage_collector/templates/site.yaml.j2
@@ -1,0 +1,5 @@
+---
+{{ usage_collector_site_key }}:
+  site_name: "{{ usage_collector_site_name }}"
+  data_dir: "{{ usage_collector_data_dir }}"
+  db_uri: "{{ usage_collector_db_uri }}"

--- a/roles/usage_collector/templates/usage-env.j2
+++ b/roles/usage_collector/templates/usage-env.j2
@@ -1,0 +1,5 @@
+# It's very important that these values are not quoted!
+
+AWS_ENDPOINT_URL={{ usage_collector_s3_endpoint }}
+AWS_ACCESS_KEY_ID={{ usage_collector_s3_access_key_id }}
+AWS_SECRET_ACCESS_KEY={{ usage_collector_secret_access_key }}

--- a/roles/usage_collector/templates/usage_collector.service.j2
+++ b/roles/usage_collector/templates/usage_collector.service.j2
@@ -1,0 +1,19 @@
+[Unit]
+Description=Chameleon Usage Reporting Collector
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/docker run \
+    --rm \
+    --net host \
+    -v {{ usage_collector_config_dir }}/site.yaml:/etc/site.yaml:ro \
+    --env-file {{ usage_collector_config_dir }}/usage-env \
+    {{ usage_collector_image_full }} \
+    extract \
+        --config /etc/site.yaml \
+        --site {{ usage_collector_site_key }}
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/usage_collector/templates/usage_collector.timer.j2
+++ b/roles/usage_collector/templates/usage_collector.timer.j2
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run Chameleon Usage Reporting Collector Periodically
+
+[Timer]
+OnCalendar={{ usage_collector_timer }}
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
role to deploy the new usage collector.
For now, it is configured to run daily, and to use a SHA tagged docker image.

Once we deploy audit tables, the collector will become *much* lighter weight, since it can fetch only missing roles.
At that point, we can run it more frequently.
