### PR TITLE
Remove MaxLeaseDurationFilter if ExternalServiceFilter enabled

### DIFF
--- a/kolla/node_custom_config/blazar.conf
+++ b/kolla/node_custom_config/blazar.conf
@@ -7,7 +7,7 @@ cleaning_time = {{ blazar_cleaning_time_minutes }}
 exempt_projects = {% for project_id in blazar_usage_project_exemptions %}{{ project_id }}{% if not loop.last %},{% endif %}{% endfor %}
 
 {% if enable_blazar_allocation_enforcement | bool %}
-enabled_filters = MaxLeaseDurationFilter, ExternalServiceFilter
+enabled_filters = ExternalServiceFilter
 {% if blazar_external_service_endpoint is defined %}
 external_service_base_endpoint = {{ blazar_external_service_endpoint }}
 {% endif %}


### PR DESCRIPTION
Portal now has all of the functionality of the MaxLeaseDurationFilter, so if ExternalServiceFilter is enabled, we do not need the MaxLeaseDurationFilter. Right now, they are both enabled and so the shorter duration always is used.

This will mean in the future, we don't need to reconfigure blazar to grant a user a lease length exemption.