### PR TITLE
Fix/implicit reader role

### DIFF
--- a/kolla/node_custom_config/glance/policy.yaml
+++ b/kolla/node_custom_config/glance/policy.yaml
@@ -1,0 +1,18 @@
+---
+member_or_reader: role:member or role:reader
+
+get_image: role:admin or (rule:member_or_reader and (project_id:%(project_id)s or project_id:%(member_id)s or 'community':%(visibility)s or 'public':%(visibility)s or 'shared':%(visibility)s))
+get_images: role:admin or (rule:member_or_reader and project_id:%(project_id)s)
+get_image_location: role:admin or (rule:member_or_reader and project_id:%(project_id)s)
+get_member: role:admin or rule:member_or_reader and (project_id:%(project_id)s or project_id:%(member_id)s)
+get_members: role:admin or rule:member_or_reader and (project_id:%(project_id)s or project_id:%(member_id)s)
+get_metadef_namespace: role:admin or (rule:member_or_reader and (project_id:%(project_id)s or 'public':%(visibility)s))
+get_metadef_namespaces: role:admin or (rule:member_or_reader and project_id:%(project_id)s)
+get_metadef_object: role:admin or (rule:member_or_reader and (project_id:%(project_id)s or 'public':%(visibility)s)) 
+get_metadef_objects: role:admin or (rule:member_or_reader and (project_id:%(project_id)s or 'public':%(visibility)s))
+list_metadef_resource_types: role:admin or (rule:member_or_reader and (project_id:%(project_id)s or 'public':%(visibility)s))
+get_metadef_resource_type: role:admin or (rule:member_or_reader and (project_id:%(project_id)s or 'public':%(visibility)s))
+get_metadef_property: role:admin or (rule:member_or_reader and (project_id:%(project_id)s or 'public':%(visibility)s))
+get_metadef_properties: role:admin or (rule:member_or_reader and (project_id:%(project_id)s or 'public':%(visibility)s))
+get_metadef_tag: role:admin or (rule:member_or_reader and (project_id:%(project_id)s or 'public':%(visibility)s))
+get_metadef_tags: role:admin or (rule:member_or_reader and (project_id:%(project_id)s or 'public':%(visibility)s))

--- a/kolla/node_custom_config/nova/policy.yaml
+++ b/kolla/node_custom_config/nova/policy.yaml
@@ -56,3 +56,7 @@
 "os_compute_api:os-hypervisors:uptime": "role:osg or rule:admin_or_owner"
 "os_compute_api:os-hypervisors:search": "role:osg or rule:admin_or_owner"
 "os_compute_api:os-hypervisors:servers": "role:osg or rule:admin_or_owner"
+
+# Original: #"project_reader_api": "role:reader and project_id:%(project_id)s"
+# replace due to keystone app credential not honoring implicit roles
+"project_reader_api": "(role:reader or role:member) and project_id:%(project_id)s"


### PR DESCRIPTION
Workaround for this bug: https://bugs.launchpad.net/keystone/+bug/2030061

In 2023.1, keystone does not honor implied roles for application credentials. In particular, nova and glance have policies that refer to the `reader` role, which is supposed to be implied by the `member` role.

However, when app credentials are used, unless a user explicitly sets the reader AND member roles on the credential, they will fail permission checks.

This should be reverted once we update to 2024.1+ just to reduce noise in the policy files, but there's no explicit downside.