### PR TITLE
add more audit tables for cloud traces

### DIFF
--- a/roles/audit_tables/defaults/main.yml
+++ b/roles/audit_tables/defaults/main.yml
@@ -4,6 +4,9 @@ audit_blazar_computehosts: false
 audit_blazar_computehost_extra_capabilities: "{{ audit_blazar_computehosts }}"
 audit_blazar_resource_properties: "{{ audit_blazar_computehosts }}"
 
+audit_nova_compute_nodes: false
+audit_nova_services: "{{ audit_nova_compute_nodes }}"
+
 audit_tables:
   - name: blazar_computehosts
     source_db: blazar
@@ -58,3 +61,73 @@ audit_tables:
       - property_name
       - private
       - is_unique
+  - name: nova_compute_nodes
+    source_db: nova
+    source_table: compute_nodes
+    grant_user: nova
+    enabled: "{{ audit_nova_compute_nodes }}"
+    columns:
+      - created_at
+      - updated_at
+      - deleted_at
+      - id
+      - service_id
+      - vcpus
+      - memory_mb
+      - local_gb
+      - vcpus_used
+      - memory_mb_used
+      - local_gb_used
+      - hypervisor_type
+      - hypervisor_version
+      - current_workload
+      - running_vms
+      - hypervisor_hostname
+      - host_ip
+      - supported_instances
+      - host
+      - ram_allocation_ratio
+      - cpu_allocation_ratio
+      - uuid
+      - disk_allocation_ratio
+      - mapped
+    watch_columns:
+      - vcpus
+      - cpu_allocation_ratio
+      - memory_mb
+      - ram_allocation_ratio
+      - local_gb
+      - disk_allocation_ratio
+      - hypervisor_hostname
+      - host
+      - hypervisor_version
+      - supported_instances
+      - mapped
+  - name: nova_services
+    source_db: nova
+    source_table: services
+    grant_user: nova
+    enabled: "{{ audit_nova_services }}"
+    columns:
+      - created_at
+      - updated_at
+      - deleted_at
+      - id
+      - host
+      - binary
+      - topic
+      - report_count
+      - disabled
+      - disabled_reason
+      - last_seen_up
+      - forced_down
+      - version
+      - uuid
+    watch_columns:
+      - host
+      - binary
+      - topic
+      - disabled
+      - disabled_reason
+      - forced_down
+      - version

--- a/roles/audit_tables/defaults/main.yml
+++ b/roles/audit_tables/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 
 audit_blazar_computehosts: false
+audit_blazar_computehost_extra_capabilities: "{{ audit_blazar_computehosts }}"
+audit_blazar_resource_properties: "{{ audit_blazar_computehosts }}"
 
 audit_tables:
   - name: blazar_computehosts
@@ -23,3 +25,36 @@ audit_tables:
       - status
       - reservable
       - disabled
+  - name: blazar_computehost_extra_capabilities
+    source_db: blazar
+    source_table: computehost_extra_capabilities
+    grant_user: blazar
+    enabled: "{{ audit_blazar_computehost_extra_capabilities }}"
+    columns:
+      - created_at
+      - updated_at
+      - deleted_at
+      - id
+      - computehost_id
+      - capability_value
+      - property_id
+    watch_columns:
+      - capability_value
+  - name: blazar_resource_properties
+    source_db: blazar
+    source_table: resource_properties
+    grant_user: blazar
+    enabled: "{{ audit_blazar_resource_properties }}"
+    columns:
+      - created_at
+      - updated_at
+      - deleted_at
+      - id
+      - resource_type
+      - property_name
+      - private
+      - is_unique
+    watch_columns:
+      - property_name
+      - private
+      - is_unique

--- a/roles/audit_tables/defaults/main.yml
+++ b/roles/audit_tables/defaults/main.yml
@@ -7,6 +7,8 @@ audit_blazar_resource_properties: "{{ audit_blazar_computehosts }}"
 audit_nova_compute_nodes: false
 audit_nova_services: "{{ audit_nova_compute_nodes }}"
 
+audit_ironic_nodes: false
+
 audit_tables:
   - name: blazar_computehosts
     source_db: blazar
@@ -131,3 +133,43 @@ audit_tables:
       - disabled_reason
       - forced_down
       - version
+  - name: ironic_nodes
+    source_db: ironic
+    source_table: nodes
+    grant_user: ironic
+    enabled: "{{ audit_ironic_nodes }}"
+    columns:
+      - created_at
+      - updated_at
+      - id
+      - uuid
+      - instance_uuid
+      - power_state
+      - target_power_state
+      - provision_state
+      - target_provision_state
+      - last_error
+      - driver
+      - reservation
+      - maintenance
+      - provision_updated_at
+      - instance_info
+      - maintenance_reason
+      - name
+      - resource_class
+      - owner
+      - lessee
+      - retired
+      - retired_reason
+      - fault
+    watch_columns:
+      # - power_state # will change multiple times per instance
+      # - provision_state # will change multiple times per instance
+      # - instance_uuid # we'll get this from instance table
+      - maintenance
+      - maintenance_reason
+      - retired
+      - owner   # shouldn't change, but maybe in future
+      - lessee  # shouldn't change, but maybe in future
+      - fault
+      - resource_class

--- a/roles/audit_tables/tasks/main.yml
+++ b/roles/audit_tables/tasks/main.yml
@@ -13,7 +13,7 @@
       login_password: "{{ database_password }}"
       query: "CREATE DATABASE IF NOT EXISTS openstack_audit"
 
-- name: Deploy audit table {{ item.name }}
+- name: Deploy audit table
   become: true
   run_once: true
   delegate_to: "{{ groups['control'][0] }}"
@@ -30,7 +30,7 @@
     label: "{{ item.name }}"
   when: item.enabled | bool
 
-- name: Assert schema of audit_{{ item.name }}
+- name: Assert audit table schema
   become: true
   run_once: true
   delegate_to: "{{ groups['control'][0] }}"
@@ -53,7 +53,7 @@
     label: "{{ item.name }}"
   when: item.enabled | bool
 
-- name: Backfill audit table {{ item.name }}
+- name: Backfill audit table
   become: true
   run_once: true
   delegate_to: "{{ groups['control'][0] }}"
@@ -70,7 +70,7 @@
     label: "{{ item.name }}"
   when: item.enabled | bool
 
-- name: Drop triggers for {{ item.name }}
+- name: Drop triggers
   become: true
   run_once: true
   delegate_to: "{{ groups['control'][0] }}"

--- a/roles/audit_tables/templates/audit_backfill.sql.j2
+++ b/roles/audit_tables/templates/audit_backfill.sql.j2
@@ -13,6 +13,7 @@ WHERE NOT EXISTS (
     SELECT 1 FROM openstack_audit.audit_{{ item.name }} a
     WHERE a.id = src.id AND a.audit_event_type = 'INSERT'
 )
+{% if 'deleted_at' in item.columns %}
 -- ---
 INSERT INTO openstack_audit.audit_{{ item.name }}
     (id, audit_event_type, audit_changed_by, audit_changed_at, data)
@@ -30,3 +31,4 @@ AND NOT EXISTS (
     SELECT 1 FROM openstack_audit.audit_{{ item.name }} a
     WHERE a.id = src.id AND a.audit_event_type = 'DELETE'
 )
+{% endif %}

--- a/roles/usage_collector/defaults/main.yml
+++ b/roles/usage_collector/defaults/main.yml
@@ -46,3 +46,8 @@ usage_collector_mysql_grants:
   - chameleon_usage.node_event:SELECT
   - chameleon_usage.node_maintenance:SELECT
   - openstack_audit.audit_blazar_computehosts:SELECT
+  - openstack_audit.audit_blazar_computehost_extra_capabilities:SELECT
+  - openstack_audit.audit_blazar_resource_properties:SELECT
+  - openstack_audit.audit_nova_compute_nodes:SELECT
+  - openstack_audit.audit_nova_services:SELECT
+  - openstack_audit.audit_ironic_nodes:SELECT

--- a/roles/usage_collector/defaults/main.yml
+++ b/roles/usage_collector/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 usage_collector_image: ghcr.io/chameleoncloud/usage-exploration
-usage_collector_tag: sha-e3fe537
+usage_collector_tag: latest
 usage_collector_image_full: "{{ usage_collector_image }}:{{ usage_collector_tag }}"
 
 usage_collector_config_dir: /etc/chameleon_usage_collector

--- a/roles/usage_collector/tasks/main.yml
+++ b/roles/usage_collector/tasks/main.yml
@@ -104,3 +104,9 @@
     name: usage_collector.timer
     enabled: yes
     state: started
+
+- name: Run usage_collector now
+  become: true
+  systemd:
+    name: usage_collector.service
+    state: started


### PR DESCRIPTION
Starting with blazar extra capabilitites and resource_properties
this should ensure we can track how the properties change over time for each host.