### PR TITLE
Fix audit table backfill performance

### DIFF
--- a/roles/audit_tables/defaults/main.yml
+++ b/roles/audit_tables/defaults/main.yml
@@ -17,6 +17,7 @@ audit_tables:
     source_db: blazar
     source_table: computehosts
     grant_user: blazar
+    id_type: "VARCHAR(36)"
     enabled: "{{ audit_blazar_computehosts }}"
     columns:
       - id
@@ -37,6 +38,7 @@ audit_tables:
     source_db: blazar
     source_table: computehost_extra_capabilities
     grant_user: blazar
+    id_type: "VARCHAR(36)"
     enabled: "{{ audit_blazar_computehost_extra_capabilities }}"
     columns:
       - created_at
@@ -52,6 +54,7 @@ audit_tables:
     source_db: blazar
     source_table: resource_properties
     grant_user: blazar
+    id_type: "VARCHAR(36)"
     enabled: "{{ audit_blazar_resource_properties }}"
     columns:
       - created_at
@@ -70,6 +73,7 @@ audit_tables:
     source_db: nova
     source_table: compute_nodes
     grant_user: nova
+    id_type: "INT(11)"
     enabled: "{{ audit_nova_compute_nodes }}"
     columns:
       - created_at
@@ -112,6 +116,7 @@ audit_tables:
     source_db: nova
     source_table: services
     grant_user: nova
+    id_type: "INT(11)"
     enabled: "{{ audit_nova_services }}"
     columns:
       - created_at
@@ -140,6 +145,7 @@ audit_tables:
     source_db: nova
     source_table: instances
     grant_user: nova
+    id_type: "INT(11)"
     enabled: "{{ audit_nova_instances }}"
     columns:
       - created_at
@@ -213,6 +219,7 @@ audit_tables:
     source_db: nova
     source_table: instance_actions
     grant_user: nova
+    id_type: "INT(11)"
     enabled: "{{ audit_nova_instance_actions }}"
     columns:
       - created_at
@@ -235,6 +242,7 @@ audit_tables:
     source_db: nova
     source_table: instance_actions_events
     grant_user: nova
+    id_type: "INT(11)"
     enabled: "{{ audit_nova_instance_actions_events }}"
     columns:
       - created_at
@@ -258,6 +266,7 @@ audit_tables:
     source_db: ironic
     source_table: nodes
     grant_user: ironic
+    id_type: "INT(11)"
     enabled: "{{ audit_ironic_nodes }}"
     columns:
       - created_at

--- a/roles/audit_tables/tasks/main.yml
+++ b/roles/audit_tables/tasks/main.yml
@@ -54,6 +54,25 @@
     label: "{{ item.name }}"
   when: item.enabled | bool
 
+- name: Migrate audit id column type
+  become: true
+  run_once: true
+  delegate_to: "{{ groups['control'][0] }}"
+  kolla_toolbox:
+    container_engine: "{{ kolla_container_engine }}"
+    module_name: community.mysql.mysql_query
+    module_args:
+      login_host: "{{ database_address }}"
+      login_user: "{{ database_user }}"
+      login_password: "{{ database_password }}"
+      query: >-
+        ALTER TABLE openstack_audit.audit_{{ item.name }}
+        MODIFY COLUMN id {{ item.id_type | default('VARCHAR(36)') }}
+  loop: "{{ audit_tables }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when: item.enabled | bool
+
 - name: Assert audit table schema
   become: true
   run_once: true

--- a/roles/audit_tables/tasks/main.yml
+++ b/roles/audit_tables/tasks/main.yml
@@ -46,6 +46,9 @@
           ALTER TABLE openstack_audit.audit_{{ item.name }}
           MODIFY COLUMN audit_event_time DATETIME DEFAULT CURRENT_TIMESTAMP,
           MODIFY COLUMN audit_changed_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        - >-
+          CREATE INDEX IF NOT EXISTS idx_id_event_type
+          ON openstack_audit.audit_{{ item.name }} (id, audit_event_type)
   loop: "{{ audit_tables }}"
   loop_control:
     label: "{{ item.name }}"

--- a/roles/audit_tables/tasks/main.yml
+++ b/roles/audit_tables/tasks/main.yml
@@ -30,6 +30,27 @@
     label: "{{ item.name }}"
   when: item.enabled | bool
 
+- name: Migrate audit timestamp columns to datetime
+  become: true
+  run_once: true
+  delegate_to: "{{ groups['control'][0] }}"
+  kolla_toolbox:
+    container_engine: "{{ kolla_container_engine }}"
+    module_name: community.mysql.mysql_query
+    module_args:
+      login_host: "{{ database_address }}"
+      login_user: "{{ database_user }}"
+      login_password: "{{ database_password }}"
+      query:
+        - >-
+          ALTER TABLE openstack_audit.audit_{{ item.name }}
+          MODIFY COLUMN audit_event_time DATETIME DEFAULT CURRENT_TIMESTAMP,
+          MODIFY COLUMN audit_changed_at DATETIME DEFAULT CURRENT_TIMESTAMP
+  loop: "{{ audit_tables }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when: item.enabled | bool
+
 - name: Assert audit table schema
   become: true
   run_once: true

--- a/roles/audit_tables/templates/audit_backfill.sql.j2
+++ b/roles/audit_tables/templates/audit_backfill.sql.j2
@@ -9,10 +9,13 @@ SELECT
         {% for col in item.columns %}'{{ col }}', src.{{ col }}{{ ',' if not loop.last }}
         {% endfor %})
 FROM {{ item.source_db }}.{{ item.source_table }} src
-WHERE NOT EXISTS (
-    SELECT 1 FROM openstack_audit.audit_{{ item.name }} a
-    WHERE a.id = src.id AND a.audit_event_type = 'INSERT'
-)
+JOIN (
+    SELECT s.id FROM {{ item.source_db }}.{{ item.source_table }} s
+    WHERE NOT EXISTS (
+        SELECT 1 FROM openstack_audit.audit_{{ item.name }} a
+        WHERE a.id = s.id AND a.audit_event_type = 'INSERT'
+    )
+) missing ON missing.id = src.id
 {% if 'deleted_at' in item.columns %}
 -- ---
 INSERT INTO openstack_audit.audit_{{ item.name }}
@@ -26,9 +29,12 @@ SELECT
         {% for col in item.columns %}'{{ col }}', src.{{ col }}{{ ',' if not loop.last }}
         {% endfor %})
 FROM {{ item.source_db }}.{{ item.source_table }} src
-WHERE src.deleted_at IS NOT NULL
-AND NOT EXISTS (
-    SELECT 1 FROM openstack_audit.audit_{{ item.name }} a
-    WHERE a.id = src.id AND a.audit_event_type = 'DELETE'
-)
+JOIN (
+    SELECT s.id FROM {{ item.source_db }}.{{ item.source_table }} s
+    WHERE s.deleted_at IS NOT NULL
+    AND NOT EXISTS (
+        SELECT 1 FROM openstack_audit.audit_{{ item.name }} a
+        WHERE a.id = s.id AND a.audit_event_type = 'DELETE'
+    )
+) missing ON missing.id = src.id
 {% endif %}

--- a/roles/audit_tables/templates/audit_backfill.sql.j2
+++ b/roles/audit_tables/templates/audit_backfill.sql.j2
@@ -1,3 +1,5 @@
+SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED
+-- ---
 INSERT INTO openstack_audit.audit_{{ item.name }}
     (id, audit_event_type, audit_event_time, audit_changed_by, data)
 SELECT

--- a/roles/audit_tables/templates/audit_table.sql.j2
+++ b/roles/audit_tables/templates/audit_table.sql.j2
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS openstack_audit.audit_{{ item.name }} (
     audit_id INT AUTO_INCREMENT PRIMARY KEY,
-    id VARCHAR(36),
+    id {{ item.id_type | default('VARCHAR(36)') }},
     audit_event_type ENUM('INSERT', 'UPDATE', 'DELETE'),
     audit_event_time DATETIME DEFAULT CURRENT_TIMESTAMP,
     audit_changed_by VARCHAR(255),

--- a/roles/audit_tables/templates/audit_table.sql.j2
+++ b/roles/audit_tables/templates/audit_table.sql.j2
@@ -7,6 +7,7 @@ CREATE TABLE IF NOT EXISTS openstack_audit.audit_{{ item.name }} (
     audit_changed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     data JSON,
     INDEX idx_id_event_time (id, audit_event_time),
+    INDEX idx_id_event_type (id, audit_event_type),
     INDEX idx_changed_at (audit_changed_at)
 )
 -- ---

--- a/roles/audit_tables/templates/audit_table.sql.j2
+++ b/roles/audit_tables/templates/audit_table.sql.j2
@@ -2,9 +2,9 @@ CREATE TABLE IF NOT EXISTS openstack_audit.audit_{{ item.name }} (
     audit_id INT AUTO_INCREMENT PRIMARY KEY,
     id VARCHAR(36),
     audit_event_type ENUM('INSERT', 'UPDATE', 'DELETE'),
-    audit_event_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    audit_event_time DATETIME DEFAULT CURRENT_TIMESTAMP,
     audit_changed_by VARCHAR(255),
-    audit_changed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    audit_changed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     data JSON,
     INDEX idx_id_event_time (id, audit_event_time),
     INDEX idx_changed_at (audit_changed_at)


### PR DESCRIPTION
Backfilling the audit tables, particularly nova.instances, was failing due to several edge cases in how mariadb queries work.

- use DATETIME instead of TIMESTAMP, as TIMESTAMP causes really odd timezone issues
- use a subquery to avoid generating json for unselected rows, and add an index for the check to see if we need to add a row
- avoid locking the source table, crucial to prevent nova.instances from becoming unavailable for minutes
- and fix an accidental string-int comparison that made the index added in commit 2 useless