### PR TITLE
Add site name to site specific services/timers

### DIFF
--- a/roles/chameleon_image_tools/tasks/main.yml
+++ b/roles/chameleon_image_tools/tasks/main.yml
@@ -39,7 +39,7 @@
   become: yes
   template:
     src: chameleon-image-deploy.service.j2
-    dest: /etc/systemd/system/chameleon-image-deploy.service
+    dest: /etc/systemd/system/{{ chameleon_site_name }}-chameleon-image-deploy.service
     mode: '0644'
   when: enable_image_deployer | bool
 

--- a/roles/hammers/tasks/install_unit.yml
+++ b/roles/hammers/tasks/install_unit.yml
@@ -14,11 +14,11 @@
     - name: template unit file
       template:
         src: hammers.service.j2
-        dest: "/etc/systemd/system/{{ service_name }}.service"
+        dest: "/etc/systemd/system/{{ chameleon_site_name }}-{{ service_name }}.service"
     - name: template timer file
       template:
         src: hammers.timer.j2
-        dest: "/etc/systemd/system/{{ service_name }}.timer"
+        dest: "/etc/systemd/system/{{ chameleon_site_name }}-{{ service_name }}.timer"
     - name: Set timer state
       ansible.builtin.systemd_service:
         name: "{{ service_name }}.timer"

--- a/roles/redfish_monitor/tasks/main.yml
+++ b/roles/redfish_monitor/tasks/main.yml
@@ -24,7 +24,7 @@
 - name: Create redfish_monitor services.
   template:
     src: "redfish_monitor.service.j2"
-    dest: "/usr/lib/systemd/system/redfish_monitor.service"
+    dest: "/usr/lib/systemd/system/{{ chameleon_site_name }}-redfish_monitor.service"
   notify:
     - reload systemd daemon
     - restart redfish monitor

--- a/roles/usage_collector/tasks/main.yml
+++ b/roles/usage_collector/tasks/main.yml
@@ -83,14 +83,14 @@
   become: true
   template:
     src: usage_collector.service.j2
-    dest: /etc/systemd/system/usage_collector.service
+    dest: /etc/systemd/system/{{ chameleon_site_name }}-usage_collector.service
     mode: "0644"
 
 - name: Deploy usage_collector timer unit
   become: true
   template:
     src: usage_collector.timer.j2
-    dest: /etc/systemd/system/usage_collector.timer
+    dest: /etc/systemd/system/{{ chameleon_site_name }}-usage_collector.timer
     mode: "0644"
 
 - name: Reload systemd


### PR DESCRIPTION
This adds the site name to the systemd services/timers rather than using names that may collide if a deploy host is used for multiple sites. I'm not 100% sure if this covers everything, but the other systemd services seemed like central services, rather than site specific ones.