### PR TITLE
Feature/integration tests

### DIFF
--- a/.github/workflows/config-tests.yml
+++ b/.github/workflows/config-tests.yml
@@ -26,3 +26,33 @@ jobs:
         run: pip install -r testing/requirements-test.txt
       - name: Run unit tests
         run: pytest testing/unit/ -v -rf --tb=short
+
+  integration:
+    name: Integration tests (genconfig)
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y python3-venv rsync
+      - name: Install chi-in-a-box dependencies
+        run: ./cc-ansible install_deps
+      - name: Install test dependencies
+        run: |
+          source venv/bin/activate
+          pip install -r testing/requirements-test.txt
+      - name: Run integration tests
+        run: |
+          source venv/bin/activate
+          pytest testing/integration/ -v -rf --tb=short
+      - name: Upload rendered configs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: genconfig-output
+          path: /tmp/pytest-*/**/output/
+          retention-days: 7

--- a/testing/Dockerfile
+++ b/testing/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && apt-get install -y \
+    python3 python3-pip python3-venv \
+    git rsync wget curl iproute2 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt/chi-in-a-box
+
+# Copy dependency files first (changes rarely, cacheable layer)
+# .git and .gitmodules needed for `git submodule update --init` in install_deps
+COPY .git .git
+COPY .gitmodules cc-ansible requirements.txt requirements.yml ./
+COPY src/kolla-ansible src/kolla-ansible
+
+# install_deps: creates venv, installs kolla-ansible, ansible, yq, galaxy roles
+RUN ./cc-ansible install_deps
+
+# Copy test requirements and install into the same venv
+COPY testing/requirements-test.txt testing/requirements-test.txt
+RUN venv/bin/pip install -r testing/requirements-test.txt
+
+# Now copy everything else (changes often, but deps are cached above)
+COPY . .
+
+ENV PATH="/opt/chi-in-a-box/venv/bin:$PATH"
+
+WORKDIR /opt/chi-in-a-box/testing
+
+ENTRYPOINT ["pytest"]
+CMD ["-v", "-rf", "--tb=short"]

--- a/testing/integration/conftest.py
+++ b/testing/integration/conftest.py
@@ -1,0 +1,162 @@
+"""Fixtures for integration tests. Requires cc-ansible install_deps."""
+
+import configparser
+import os
+import shutil
+import subprocess
+import yaml
+import pytest
+from pathlib import Path
+
+# Derived here rather than imported — conftest files aren't importable as modules.
+CIAB_DIR = Path(__file__).resolve().parents[2]
+
+
+class GenconfigResult:
+    """Parsed genconfig output."""
+
+    def __init__(self, output_dir: Path):
+        self.output_dir = output_dir
+
+    def ini(self, service, filename="") -> configparser.ConfigParser:
+        if not filename:
+            filename = service.split("-")[0] + ".conf"
+        conf = configparser.ConfigParser(strict=False, allow_no_value=True)
+        conf.read(self.output_dir / service / filename)
+        return conf
+
+    def text(self, service, filename) -> str:
+        return (self.output_dir / service / filename).read_text()
+
+    def services(self) -> list:
+        return [d.name for d in self.output_dir.iterdir() if d.is_dir()]
+
+
+def _build_site_config(tmp_path, overrides, extra_files=None):
+    site_dir = tmp_path / "site-config"
+    shutil.copytree(CIAB_DIR / "site-config.example", site_dir)
+
+    (site_dir / "defaults.yml").write_text(yaml.dump(overrides))
+
+    # Safety: only modify files inside the pytest tmpdir
+    assert str(site_dir).startswith(str(tmp_path)), \
+        f"Refusing to modify {site_dir} outside tmpdir {tmp_path}"
+
+    # Replace example inventory with test inventory (localhost, no SSH)
+    inv_dir = site_dir / "inventory"
+    (inv_dir / "hosts").unlink(missing_ok=True)
+    test_inv = CIAB_DIR / "testing" / "inventory"
+    for f in test_inv.iterdir():
+        if f.is_dir():
+            shutil.copytree(f, inv_dir / f.name, dirs_exist_ok=True)
+        else:
+            shutil.copy(f, inv_dir / f.name)
+
+    for rel_path, content in (extra_files or {}).items():
+        dest = site_dir / rel_path
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        if isinstance(content, str):
+            dest.write_text(content)
+        else:
+            dest.write_text(yaml.dump(content))
+
+    pw_file = site_dir / "passwords.yml"
+    subprocess.run(
+        ["kolla-genpwd", "-p", str(pw_file)],
+        check=True, capture_output=True,
+    )
+    (site_dir / "vault_password").write_text("dummy")
+
+    return site_dir
+
+
+def run_genconfig(tmp_path, overrides, extra_files=None):
+    site_dir = _build_site_config(tmp_path, overrides, extra_files)
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    env = {**os.environ, "CC_ANSIBLE_SITE": str(site_dir)}
+    result = subprocess.run(
+        [str(CIAB_DIR / "cc-ansible"), "genconfig",
+         "--extra", f"node_config_directory={output_dir}"],
+        env=env, capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"genconfig failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+        )
+
+    return GenconfigResult(output_dir)
+
+
+# --- Profile variable sets ---
+
+MINIMAL_VARS = {
+    "kolla_internal_vip_address": "172.18.200.254",
+    "kolla_external_vip_address": "172.18.200.254",
+    "network_interface": "eth0",
+    "neutron_external_interface": "eth1",
+    "kolla_base_distro": "ubuntu",
+    # Override the default /etc/ansible/venv/bin/python which is created by
+    # bootstrap-servers on real hosts. In test we just use system python3.
+    "ansible_python_interpreter": "python3",
+}
+
+KVM_VARS = {
+    **MINIMAL_VARS,
+    "openstack_region_name": "TestKVM",
+    "enable_ironic": False,
+    "nova_compute_virt_type": "kvm",
+    "blazar_enable_flavor_reservation": True,
+    "blazar_flavor_reservation_trait": "CUSTOM_TEST_TRAIT",
+    "blazar_enable_host_reservation": False,
+    "enable_blazar_allocation_enforcement": True,
+    "blazar_filter_vm_hosts": True,
+    "blazar_filter_ironic_hosts": True,
+}
+
+KVM_GPU_VARS = {**KVM_VARS}
+
+KVM_GPU_EXTRA_FILES = {
+    "inventory/host_vars/localhost.yml": yaml.dump({
+        "gpu": True,
+        "node_reserved_memory_mb": 65536,
+        "nova_pci_device_spec": [
+            {"vendor_id": "10de", "product_id": "2339",
+             "traits": "CUSTOM_GPU_H100,CUSTOM_GPU"},
+        ],
+        "nova_pci_alias": [
+            {"name": "h100", "vendor_id": "10de",
+             "product_id": "2339", "device_type": "type-PF"},
+        ],
+    }),
+}
+
+
+# --- Fixtures ---
+
+@pytest.fixture(scope="session")
+def install_deps():
+    venv = CIAB_DIR / "venv"
+    if not (venv / "bin" / "kolla-ansible").exists():
+        subprocess.run(
+            [str(CIAB_DIR / "cc-ansible"), "install_deps"],
+            check=True,
+        )
+
+
+@pytest.fixture(scope="session")
+def minimal_config(install_deps, tmp_path_factory):
+    return run_genconfig(tmp_path_factory.mktemp("minimal"), MINIMAL_VARS)
+
+
+@pytest.fixture(scope="session")
+def kvm_config(install_deps, tmp_path_factory):
+    return run_genconfig(tmp_path_factory.mktemp("kvm"), KVM_VARS)
+
+
+@pytest.fixture(scope="session")
+def kvm_gpu_config(install_deps, tmp_path_factory):
+    return run_genconfig(
+        tmp_path_factory.mktemp("kvm-gpu"), KVM_GPU_VARS, KVM_GPU_EXTRA_FILES,
+    )

--- a/testing/integration/test_genconfig.py
+++ b/testing/integration/test_genconfig.py
@@ -1,0 +1,28 @@
+"""Integration tests: run genconfig and assert on rendered config.
+
+These tests require cc-ansible install_deps to have been run.
+All output is sandboxed to pytest tmpdirs.
+
+Run via Docker for isolation:
+    docker build -f testing/Dockerfile -t ciab-test .
+    docker run ciab-test testing/integration/ -v
+"""
+
+
+class TestMinimalProfile:
+    """Bare minimum config renders without errors."""
+
+    def test_genconfig_succeeds(self, minimal_config):
+        assert minimal_config.output_dir.exists()
+
+    def test_key_services_rendered(self, minimal_config):
+        services = minimal_config.services()
+        for svc in ["keystone", "horizon", "neutron-server", "nova-api"]:
+            assert svc in services, f"Missing service: {svc}"
+
+    def test_no_raw_jinja2_in_configs(self, minimal_config):
+        for conf_file in minimal_config.output_dir.rglob("*.conf"):
+            content = conf_file.read_text()
+            assert "{{" not in content, (
+                f"Unrendered Jinja2 in {conf_file.relative_to(minimal_config.output_dir)}"
+            )

--- a/testing/inventory/host_vars/localhost.yml
+++ b/testing/inventory/host_vars/localhost.yml
@@ -1,0 +1,24 @@
+---
+# Fake ansible_facts so kolla_address filter can resolve interfaces
+# without real NICs. Used by genconfig integration tests.
+ansible_facts:
+  ansible_os_family: Debian
+  ansible_distribution: Ubuntu
+  ansible_distribution_version: "22.04"
+  ansible_architecture: x86_64
+  ansible_eth0:
+    active: true
+    device: eth0
+    ipv4:
+      address: 172.18.200.1
+      netmask: 255.255.255.0
+    type: ether
+  ansible_eth1:
+    active: true
+    device: eth1
+    type: ether
+  ansible_default_ipv4:
+    address: 172.18.200.1
+    interface: eth0
+  ansible_hostname: localhost
+  ansible_fqdn: localhost


### PR DESCRIPTION
Add tests to exercise "install_deps" and "genconfig"

Pytest fixtures allow passing composable sets of "defaults.yml" entries, then parsing the templated ini output files and asserting on the contents.

The goal is that we'll be able to say "chi-in-a-box supports specifying pci passthrough with syntax X"
And if we break a template, or kolla-ansible drops a default var, or something else goes wrong, the test breaks.

Hopefully this will help prevent surprises when doing things like merging KVM and Baremetal, without incurring too much maintenance overhead.