### PR TITLE
port hammers and playbooks to kvm_vendordata :(

### DIFF
--- a/cc-ansible
+++ b/cc-ansible
@@ -2,12 +2,17 @@
 
 set -euo pipefail
 
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 
 declare -a POSARGS=()
 
 while [[ $# -gt 0 ]]; do
     key="$1"
     case $key in
+        -p|--playbook)
+            CC_ANSIBLE_PLAYBOOK="$(realpath "$2")"
+            shift # Past arg
+            ;;
         -s|--site)
             KA_SITE_ARG="$(realpath "$2")"
             shift # Past arg
@@ -32,6 +37,33 @@ KA_INVENTORY=${KA_INVENTORY:-"${KA_SITE}/inventory"}
 # if cmdline arg set, override env var and default
 KA_INVENTORY=${KA_INVENTORY_ARG:-$KA_INVENTORY}
 
+
+# Handle --playbook: copy into kolla-ansible's ansible dir so group_vars work,
+# then invoke kolla-ansible with 'deploy --playbook <path>'
+if [[ -n "${CC_ANSIBLE_PLAYBOOK:-}" ]]; then
+    KA_ANSIBLE_DIR="${VIRTUAL_ENV:-$(dirname $(command -v kolla-ansible))/..}/share/kolla-ansible/ansible"
+    if [[ ! -d "$KA_ANSIBLE_DIR" ]]; then
+        echo "Error: Cannot find kolla-ansible ansible dir at $KA_ANSIBLE_DIR"
+        exit 1
+    fi
+
+    playbook_file="$KA_ANSIBLE_DIR/$(basename "$CC_ANSIBLE_PLAYBOOK")"
+    cp "$CC_ANSIBLE_PLAYBOOK" "$playbook_file"
+    cleanup_playbook() { rm -f "$playbook_file"; }
+    trap cleanup_playbook EXIT
+
+    # Set up Ansible search paths for chi-in-a-box plugins/libraries
+    export ANSIBLE_ACTION_PLUGINS="$DIR/playbooks/action_plugins"
+    export ANSIBLE_LIBRARY="$DIR/playbooks/library"
+    export ANSIBLE_ROLES_PATH="$DIR/roles"
+
+    echo "**********************************************************************"
+    echo "* Playbook override: $CC_ANSIBLE_PLAYBOOK"
+    echo "* Executing within Kolla-Ansible context.                            *"
+    echo "**********************************************************************"
+
+    POSARGS=(deploy --playbook "$playbook_file")
+fi
 
 # modify positional args to pass to kolla ansible
 declare -a kolla_args=()

--- a/playbooks/hammers.yml
+++ b/playbooks/hammers.yml
@@ -1,0 +1,7 @@
+---
+- hosts: hammers
+  become: true
+  roles:
+    - hammers_v2
+  tags:
+    - hammers

--- a/roles/hammers_v2/defaults/main.yml
+++ b/roles/hammers_v2/defaults/main.yml
@@ -1,0 +1,21 @@
+---
+hammers_config_path: /etc/hammers
+hammers_docker_image: "ghcr.io/chameleoncloud/hammers:latest"
+hammers_env_file: /etc/hammers/hammers.env
+
+hammers_v2_docker_image: ghcr.io/chameleoncloud/chameleon_site_tools:main
+hammers_v2:
+  floating_ip_network_reaper:
+    description: "Clean up networks for expired projects."
+    env_file: "{{ hammers_env_file }}"
+    image: "{{ hammers_v2_docker_image }}"
+    cmd: floating_ip_network_reaper --cloud envvars --grace-days 7  --clean-floatingips --clean-routers
+    enabled: "{{ enable_neutron | bool }}"
+    calendar: daily
+  idle_lease_reaper:
+    description: "Clean up idle leases."
+    env_file: "{{ hammers_env_file }}"
+    image: "{{ hammers_v2_docker_image }}"
+    cmd: "idle_lease_reaper --cloud envvars{% if hammers_slack_webhook is defined %} --slack {{ hammers_config_path }}/slack.json{% endif %} delete"
+    enabled: "{{ blazar_enable_flavor_reservation | bool }}"
+    calendar: hourly

--- a/roles/hammers_v2/handlers/main.yml
+++ b/roles/hammers_v2/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: reload systemd
+  ansible.builtin.systemd_service:
+    daemon_reload: true

--- a/roles/hammers_v2/tasks/install_unit.yml
+++ b/roles/hammers_v2/tasks/install_unit.yml
@@ -1,0 +1,26 @@
+---
+- name: "set up service: {{ item.key }}"
+  vars:
+    container_name: "{{ item.value.container_name | default(item.key)}}"
+    description: "{{item.value.description | default(item.key) }}"
+    env_file: "{{item.value.env_file | default(hammers_env_file)}}"
+    image: "{{item.value.image | default(hammers_docker_image) }}"
+    cmd: "{{item.value.cmd}}"
+    calendar: "{{item.value.calendar | default(daily) }}"
+    enabled: "{{item.value.enabled}}"
+  notify:
+    - reload systemd
+  block:
+    - name: template unit file
+      template:
+        src: hammers.service.j2
+        dest: "/etc/systemd/system/{{ service_name }}.service"
+    - name: template timer file
+      template:
+        src: hammers.timer.j2
+        dest: "/etc/systemd/system/{{ service_name }}.timer"
+    - name: Set timer state
+      ansible.builtin.systemd_service:
+        name: "{{ service_name }}.timer"
+        state: "{{ timer_state }}"
+        enabled: "{{ timer_enabled }}"

--- a/roles/hammers_v2/tasks/main.yml
+++ b/roles/hammers_v2/tasks/main.yml
@@ -1,0 +1,29 @@
+---
+- name: Create config directory.
+  become: true
+  file:
+    path: "{{ hammers_config_path }}"
+    state: directory
+
+- name: Configure Hammers env file
+  become: true
+  template:
+    src: hammers.env.j2
+    mode: 0600
+    dest: "{{ hammers_env_file }}"
+
+- name: Configure slack webhook file
+  become: true
+  template:
+    src: slack.json.j2
+    mode: 0600
+    dest: "{{ hammers_config_path }}/slack.json"
+  when: hammers_slack_webhook is defined
+
+- name: Install hammers_v2 systemd units
+  include_tasks: install_unit.yml
+  vars:
+    service_name: "hammer_{{ item.key }}"
+    timer_state: "{{ 'started' if item.value.enabled else 'stopped' }}"
+    timer_enabled: "{{item.value.enabled}}"
+  loop: "{{ hammers_v2 | dict2items }}"

--- a/roles/hammers_v2/templates/hammers.env.j2
+++ b/roles/hammers_v2/templates/hammers.env.j2
@@ -1,0 +1,10 @@
+OS_AUTH_STRATEGY=keystone
+OS_AUTH_URL={{ keystone_internal_url }}/v3
+OS_USERNAME={{ hammers_openstack_user }}
+OS_PASSWORD={{ hammers_openstack_password }}
+OS_PROJECT_NAME={{ hammers_openstack_project_name }}
+OS_USER_DOMAIN_NAME=default
+OS_PROJECT_DOMAIN_NAME=default
+OS_REGION_NAME={{ openstack_region_name }}
+OS_IDENTITY_API_VERSION=3
+OS_IRONIC_API_VERSION=1.29

--- a/roles/hammers_v2/templates/hammers.service.j2
+++ b/roles/hammers_v2/templates/hammers.service.j2
@@ -1,0 +1,20 @@
+# {{ ansible_managed }}
+
+[Unit]
+Description={{ description }}
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/docker run \
+    --net=host \
+    --rm \
+    --name {{ container_name }} \
+    --label org.chameleoncloud.hammer={{ container_name }} \
+    --env-file {{ env_file }} \
+    -v "{{hammers_config_path}}:{{hammers_config_path}}:ro" \
+    {{ image }} \
+    {{ cmd }} 
+[Install]
+WantedBy=multi-user.target

--- a/roles/hammers_v2/templates/hammers.timer.j2
+++ b/roles/hammers_v2/templates/hammers.timer.j2
@@ -1,0 +1,13 @@
+# {{ ansible_managed }}
+
+[Unit]
+Description={{ description }}
+
+[Timer]
+OnCalendar={{ calendar }}
+RandomizedDelaySec=3h
+AccuracySec=1s
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/roles/hammers_v2/templates/slack.json.j2
+++ b/roles/hammers_v2/templates/slack.json.j2
@@ -1,0 +1,9 @@
+{
+    "webhook": "{{ hammers_slack_webhook }}",
+    "hostname_names": {
+        "m01-07.chameleon.tacc.utexas.edu": "CHI@TACC",
+        "chi01.tacc.chameleoncloud.org": "CHI@TACC",
+        "m01-03.chameleon.tacc.utexas.edu": "KVM@TACC",
+        "admin01.uc.chameleoncloud.org": "CHI@UC"
+    }
+}


### PR DESCRIPTION
I think this *should* port what we need from hammers to kvm as a quick and dirty fix.

when rebasing / merging later, this commit should be totally dropped.