### PR TITLE
test(config): pytest harness with unit tests for merge + kolla sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ vagrant/vagrantkey*
 # Python build files
 *.pyc
 __pycache__/
+.pytest_cache/
+# Testing venvs
+testing/.venv/
 galaxy.ansible.com/**
 
 roles/ansible_collections

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = testing
+addopts = -v -rf --tb=short -s

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -1,0 +1,34 @@
+"""Shared paths for all chi-in-a-box tests.
+
+pytest loads conftest.py files hierarchically, so these fixtures
+are available to both unit/ and integration/ tests automatically.
+"""
+
+import yaml
+import pytest
+from pathlib import Path
+
+CIAB_DIR = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture(scope="session")
+def ciab_dir():
+    return CIAB_DIR
+
+
+@pytest.fixture(scope="session")
+def ciab_defaults_path():
+    return CIAB_DIR / "kolla" / "defaults.yml"
+
+
+@pytest.fixture(scope="session")
+def ciab_defaults(ciab_defaults_path):
+    return yaml.safe_load(ciab_defaults_path.read_text())
+
+
+@pytest.fixture(scope="session")
+def kolla_ansible_dir():
+    path = CIAB_DIR / "src" / "kolla-ansible"
+    if not path.exists():
+        pytest.skip("kolla-ansible submodule not initialized")
+    return path

--- a/testing/requirements-test.txt
+++ b/testing/requirements-test.txt
@@ -1,0 +1,2 @@
+pytest
+pyyaml

--- a/testing/unit/conftest.py
+++ b/testing/unit/conftest.py
@@ -1,0 +1,22 @@
+"""Fixtures for unit tests. No ansible or kolla-ansible needed."""
+
+import subprocess
+import yaml
+import pytest
+
+
+@pytest.fixture
+def yq_merge(tmp_path, ciab_defaults_path):
+    """Returns a function that merges overrides onto chi-in-a-box defaults via yq."""
+    def _merge(overrides):
+        override_file = tmp_path / "overrides.yml"
+        override_file.write_text(yaml.dump(overrides))
+        result = subprocess.run(
+            ["yq", "eval-all", ". as $item ireduce ({}; . * $item)",
+             str(ciab_defaults_path), str(override_file)],
+            capture_output=True, text=True,
+        )
+        if result.returncode != 0:
+            pytest.skip(f"yq not available: {result.stderr}")
+        return yaml.safe_load(result.stdout)
+    return _merge

--- a/testing/unit/test_sync.py
+++ b/testing/unit/test_sync.py
@@ -1,0 +1,70 @@
+"""Tests that chi-in-a-box stays in sync with kolla-ansible.
+
+Catches drift between upstream kolla-ansible and chi-in-a-box's
+example inventory, passwords, and defaults.
+"""
+
+import re
+import yaml
+import pytest
+
+
+def _parse_ini_groups(path):
+    """Extract group names from an ansible inventory file."""
+    groups = set()
+    for line in path.read_text().splitlines():
+        m = re.match(r'^\[([^\]:]+)', line)
+        if m:
+            groups.add(m.group(1))
+    return groups
+
+
+class TestInventorySync:
+    """Ensure chi-in-a-box example inventory has all groups kolla-ansible expects."""
+
+    def test_example_inventory_exists(self, ciab_dir):
+        assert (ciab_dir / "site-config.example" / "inventory" / "hosts").exists()
+
+    def test_no_missing_groups(self, ciab_dir, kolla_ansible_dir):
+        kolla_multinode = kolla_ansible_dir / "ansible" / "inventory" / "multinode"
+        if not kolla_multinode.exists():
+            pytest.skip("kolla-ansible multinode inventory not found")
+
+        kolla_groups = _parse_ini_groups(kolla_multinode)
+        ciab_groups = _parse_ini_groups(
+            ciab_dir / "site-config.example" / "inventory" / "hosts")
+
+        missing = kolla_groups - ciab_groups
+        allowed_missing = {"connection-plugin"}
+        missing -= allowed_missing
+
+        assert not missing, (
+            f"Groups in kolla-ansible but missing from chi-in-a-box inventory: {missing}"
+        )
+
+
+class TestPasswordsSync:
+    """Ensure chi-in-a-box passwords.yml has all keys kolla-ansible expects."""
+
+    def test_no_missing_passwords(self, ciab_dir, kolla_ansible_dir):
+        kolla_pw = kolla_ansible_dir / "etc" / "kolla" / "passwords.yml"
+        if not kolla_pw.exists():
+            pytest.skip("kolla-ansible passwords.yml not found")
+
+        kolla_keys = set(yaml.safe_load(kolla_pw.read_text()).keys())
+        ciab_keys = set(yaml.safe_load(
+            (ciab_dir / "site-config.example" / "passwords.yml").read_text()).keys())
+
+        missing = kolla_keys - ciab_keys
+        assert not missing, (
+            f"Password keys in kolla-ansible but missing from chi-in-a-box: {missing}"
+        )
+
+
+class TestDefaultsSync:
+
+    def test_defaults_is_valid_yaml(self, ciab_defaults):
+        assert isinstance(ciab_defaults, dict)
+
+    def test_openstack_release_matches(self, ciab_defaults):
+        assert "openstack_release" in ciab_defaults

--- a/testing/unit/test_variable_merge.py
+++ b/testing/unit/test_variable_merge.py
@@ -1,0 +1,57 @@
+"""Tests for the yq variable merge logic used by cc-ansible.
+
+cc-ansible merges kolla/defaults.yml + site-config/defaults.yml via:
+    yq eval-all '. as $item ireduce ({}; . * $item)' base.yml site.yml
+
+This is a deep merge where site values override base values.
+Lists are replaced entirely (not appended).
+"""
+
+
+class TestMergePrecedence:
+    """Site-config overrides take precedence over chi-in-a-box defaults."""
+
+    def test_scalar_override_wins(self, yq_merge):
+        merged = yq_merge({"blazar_enable_flavor_reservation": True})
+        assert merged["blazar_enable_flavor_reservation"] is True
+
+    def test_base_preserved_when_not_overridden(self, yq_merge):
+        merged = yq_merge({})
+        assert "enable_mariadb" in merged
+
+    def test_string_override(self, yq_merge):
+        merged = yq_merge({"openstack_region_name": "KVM@TACC"})
+        assert merged["openstack_region_name"] == "KVM@TACC"
+
+
+class TestMergeSemantics:
+    """yq ireduce replaces lists, deep-merges dicts."""
+
+    def test_list_replaced_not_appended(self, yq_merge):
+        merged = yq_merge({
+            "horizon_custom_themes": [{"name": "custom", "label": "Custom"}],
+        })
+        assert len(merged["horizon_custom_themes"]) == 1
+        assert merged["horizon_custom_themes"][0]["name"] == "custom"
+
+    def test_empty_override_is_noop(self, yq_merge, ciab_defaults):
+        merged = yq_merge({})
+        for key in ["enable_blazar", "enable_nova", "enable_keystone"]:
+            assert merged[key] == ciab_defaults[key]
+
+
+class TestDefaultsCompleteness:
+    """Verify that kolla/defaults.yml defines expected variables."""
+
+    def test_blazar_defaults_exist(self, ciab_defaults):
+        for key in [
+            "enable_blazar",
+            "blazar_minutes_before_end_lease",
+            "blazar_default_max_lease_duration",
+            "blazar_email_relay",
+        ]:
+            assert key in ciab_defaults, f"Missing default: {key}"
+
+    def test_nova_defaults_exist(self, ciab_defaults):
+        for key in ["enable_nova", "nova_compute_virt_type"]:
+            assert key in ciab_defaults, f"Missing default: {key}"


### PR DESCRIPTION
## Summary
- Introduces a pytest-based test suite for chi-in-a-box (`pytest testing/unit/`).
- Unit test: yq deep-merge semantics used by cc-ansible to combine `kolla/defaults.yml` with `site-config/defaults.yml` (scalar override, list replacement, empty-override no-op).
- Unit test: drift between the vendored kolla-ansible submodule and chi-in-a-box's example inventory groups and `passwords.yml` keys. Catches upstream renames before they reach a deploy.

## Stack
**PR 1 of 3.** Foundation for the containerized-CI work that follows.
1. **This PR** — unit tests + harness → `stable/2023.1`
2. [feature/test-harness-docker](https://github.com/ChameleonCloud/chi-in-a-box/tree/feature/test-harness-docker) — Dockerfile for reproducible test runs
3. [feature/test-harness-ci](https://github.com/ChameleonCloud/chi-in-a-box/tree/feature/test-harness-ci) — replace flaky self-hosted workflow with containerized unit-test CI

## Test plan
- [x] `pytest testing/unit/` passes locally against an initialized checkout (with `yq` on PATH and the kolla-ansible submodule present).
- [x] Sync tests skip cleanly when the submodule is not initialized.