### PR TITLE
test(genconfig): integration tests for cc-ansible genconfig

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -36,3 +36,6 @@ vagrant/vagrantkey*
 *.pyc
 **/__pycache__/
 .pytest_cache/
+
+# Rendered genconfig output preserved by integration fixtures for manual review
+testing/output/

--- a/.github/workflows/config-tests.yml
+++ b/.github/workflows/config-tests.yml
@@ -9,8 +9,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  unit:
-    name: Unit tests (containerized)
+  tests:
+    name: Config tests (containerized)
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -31,3 +31,19 @@ jobs:
 
       - name: Run unit tests
         run: docker run --rm ciab:test pytest testing/unit/
+
+      - name: Run integration tests
+        run: |
+          mkdir -p "${{ runner.temp }}/genconfig-output"
+          docker run --rm \
+            -e CIAB_PRESERVED_OUTPUT=/preserved \
+            -v "${{ runner.temp }}/genconfig-output:/preserved" \
+            ciab:test pytest testing/integration/
+
+      - name: Upload rendered genconfig
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: genconfig-output
+          path: ${{ runner.temp }}/genconfig-output/
+          retention-days: 14

--- a/.github/workflows/config-tests.yml
+++ b/.github/workflows/config-tests.yml
@@ -40,6 +40,12 @@ jobs:
             -v "${{ runner.temp }}/genconfig-output:/preserved" \
             ciab:test pytest testing/integration/
 
+      # Container runs as root; bind-mounted output files end up
+      # root-owned and the runner user can't read them to upload.
+      - name: Fix artifact ownership
+        if: always()
+        run: sudo chown -R runner:runner "${{ runner.temp }}/genconfig-output"
+
       - name: Upload rendered genconfig
         if: always()
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ testing/.venv/
 galaxy.ansible.com/**
 
 roles/ansible_collections
+
+# Rendered genconfig output preserved by integration fixtures for manual review
+testing/output/

--- a/testing/integration/conftest.py
+++ b/testing/integration/conftest.py
@@ -1,0 +1,111 @@
+"""Fixtures for genconfig integration tests.
+
+Builds a site-config from site-config.example plus a test profile
+(inventory + host_vars overlays, defaults merged via the same yq
+expression cc-ansible uses at deploy time), then runs `cc-ansible
+genconfig` end-to-end. A failure here means rendered service config
+would break on a real host.
+
+No profile parametrization yet — a single synthetic _base profile is
+enough to prove the pipeline works. A profile matrix (baremetal/kvm)
+is a later PR.
+"""
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+CIAB_DIR = Path(__file__).resolve().parents[2]
+BASE_PROFILE_DIR = CIAB_DIR / "testing" / "profiles" / "_base"
+
+
+def _merge_yaml(files):
+    """Deep-merge YAML files via the same yq expression cc-ansible uses
+    at deploy time (see cc-ansible's globals.yml build step)."""
+    if not files:
+        return {}
+    result = subprocess.run(
+        ["yq", "eval-all", ". as $item ireduce ({}; . * $item)",
+         *[str(f) for f in files]],
+        capture_output=True, text=True, check=True,
+    )
+    return yaml.safe_load(result.stdout) or {}
+
+
+def _build_site_config(dest, profile_dir):
+    shutil.copytree(CIAB_DIR / "site-config.example", dest)
+
+    # Substitute <host> -> localhost in the example inventory. [compute]
+    # is left empty, matching site-config.example; compute-side templates
+    # (nova-compute.conf etc.) will be exercised by profiles that populate
+    # [compute] with real hosts (e.g. the kvm profile).
+    hosts = dest / "inventory" / "hosts"
+    hosts.write_text(
+        hosts.read_text().replace("<host>", "localhost ansible_connection=local")
+    )
+
+    # Overlay profile inventory and host_vars. shutil.copytree with
+    # dirs_exist_ok replaces files at matching paths. Real site profiles
+    # (kvm, baremetal) ship pre-expanded inventory that fully replaces
+    # site-config.example's hosts; _base ships only host_vars overlays.
+    profile_inv = profile_dir / "inventory"
+    if profile_inv.exists():
+        shutil.copytree(profile_inv, dest / "inventory", dirs_exist_ok=True)
+
+    (dest / "defaults.yml").write_text(
+        yaml.dump(_merge_yaml([profile_dir / "defaults.yml"]))
+    )
+
+    subprocess.run(
+        ["kolla-genpwd", "-p", str(dest / "passwords.yml")],
+        check=True,
+    )
+    (dest / "vault_password").write_text("dummy")
+
+
+@pytest.fixture(scope="session")
+def install_deps():
+    if not (CIAB_DIR / "venv" / "bin" / "kolla-ansible").exists():
+        subprocess.run(
+            [str(CIAB_DIR / "cc-ansible"), "install_deps"],
+            check=True,
+        )
+
+
+@pytest.fixture(scope="session")
+def genconfig_output(install_deps, tmp_path_factory):
+    """Run genconfig once per session against the _base profile and return
+    the output directory.
+
+    A copy is preserved at $CIAB_PRESERVED_OUTPUT/_base/ (default:
+    testing/output/_base/) so the most recent render is always available
+    as a reference snapshot — useful both for debugging a failed test and
+    as an example of what default-templated config looks like."""
+    workdir = tmp_path_factory.mktemp("_base")
+    site_dir = workdir / "site-config"
+    output_dir = workdir / "output"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    _build_site_config(site_dir, BASE_PROFILE_DIR)
+
+    env = {**os.environ, "CC_ANSIBLE_SITE": str(site_dir)}
+    subprocess.run(
+        [str(CIAB_DIR / "cc-ansible"), "genconfig",
+         "--extra", f"node_config_directory={output_dir}"],
+        env=env, cwd=str(CIAB_DIR), check=True,
+    )
+
+    preserve_root = Path(
+        os.environ.get("CIAB_PRESERVED_OUTPUT", CIAB_DIR / "testing" / "output")
+    )
+    preserved = preserve_root / "_base"
+    if preserved.exists():
+        shutil.rmtree(preserved)
+    preserved.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(output_dir, preserved)
+
+    return output_dir

--- a/testing/integration/test_genconfig.py
+++ b/testing/integration/test_genconfig.py
@@ -1,0 +1,23 @@
+"""Smoke tests for `cc-ansible genconfig` end-to-end.
+
+A failure here means rendered service config would fail on a real host.
+Rendered output is preserved at testing/output/_base/ for inspection.
+"""
+
+
+def test_genconfig_produces_output(genconfig_output):
+    assert any(genconfig_output.iterdir()), "genconfig produced no service dirs"
+
+
+def test_core_services_rendered(genconfig_output):
+    services = {d.name for d in genconfig_output.iterdir() if d.is_dir()}
+    for svc in ["keystone", "horizon", "neutron-server", "nova-api"]:
+        assert svc in services, f"Missing service directory: {svc}"
+
+
+def test_no_unrendered_jinja(genconfig_output):
+    for conf in genconfig_output.rglob("*.conf"):
+        text = conf.read_text()
+        assert "{{" not in text, (
+            f"Unrendered Jinja in {conf.relative_to(genconfig_output)}"
+        )

--- a/testing/profiles/_base/defaults.yml
+++ b/testing/profiles/_base/defaults.yml
@@ -1,0 +1,13 @@
+---
+# Minimum values for cc-ansible genconfig to run against the synthetic
+# localhost inventory in testing/profiles/_base/inventory/. Every named
+# profile overlays on top of this via the same yq deep-merge cc-ansible
+# uses at deploy time (see cc-ansible, around the globals.yml build step).
+kolla_internal_vip_address: 172.18.200.254
+kolla_external_vip_address: 172.18.200.254
+network_interface: eth0
+neutron_external_interface: eth1
+kolla_base_distro: ubuntu
+# Bypass /etc/ansible/venv/bin/python (created by bootstrap-servers on
+# real hosts but not present in the test container).
+ansible_python_interpreter: python3

--- a/testing/profiles/_base/inventory/host_vars/localhost.yml
+++ b/testing/profiles/_base/inventory/host_vars/localhost.yml
@@ -1,0 +1,30 @@
+---
+# Fake ansible_facts so genconfig can render without a real host:
+#   - kolla_address (kolla-ansible filter plugin) reads ansible_<iface>.ipv4
+#     to produce listen addresses for services (api_interface, etc.).
+#   - service role tasks gate on ansible_os_family / ansible_distribution.
+#   - ansible_default_ipv4 is referenced by several templates as a fallback.
+# If a kolla-ansible bump starts reading a new fact, extend this file to
+# match. The integration test failure signal for that is a render error
+# or a missing-attribute traceback from kolla_address.
+ansible_facts:
+  ansible_os_family: Debian
+  ansible_distribution: Ubuntu
+  ansible_distribution_version: "22.04"
+  ansible_architecture: x86_64
+  ansible_eth0:
+    active: true
+    device: eth0
+    ipv4:
+      address: 172.18.200.1
+      netmask: 255.255.255.0
+    type: ether
+  ansible_eth1:
+    active: true
+    device: eth1
+    type: ether
+  ansible_default_ipv4:
+    address: 172.18.200.1
+    interface: eth0
+  ansible_hostname: localhost
+  ansible_fqdn: localhost


### PR DESCRIPTION
Wrap `cc-ansible genconfig` in a test harness. Uses a minimal defaults.yml

Using pytest (for easy parametrization), generates a minimal site-config with:
- site-config.example inventory, setting all groups to localhost
- minimum possible defaults.yml
- fake "ansible facts" in host_vars/localhost, this allows hardcoding interface names and ip addresses in the config.

The "tests" are very simple. Assuming all config generates without yelling about undefined vars, we just check the following:
- output files are created
- the expected services are created (keystone, horizon, neutron, nova)
- the output doesn't contain jinja, e.g. everything was templated, not copied.

If `CIAB_PRESERVED_OUTPUT` env var is set to a path, the templated output will be saved there. This can be useful for manual inspection and diffs.

Follow-on work will parametrize this minimal base to generate config snippets for parts of baremetal, kvm, edge, and add assertions about the contents of the templated files.