### PR TITLE
Fix(keystone): broken template with null federation

### DIFF
--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -162,7 +162,6 @@ identity_provider_name: chameleon
 identity_provider_domain_name: chameleon
 keystone_idp_client_id: null
 enable_keystone_federation: "{{ keystone_idp_client_id is truthy }}"
-keystone_enable_federation_openid: "{{ enable_keystone_federation }}"
 keystone_identity_providers:
   - name: "{{ identity_provider_name }}"
     openstack_domain: "{{ identity_provider_domain_name }}"


### PR DESCRIPTION
In kolla/defaults.yml, we were setting:
```
keystone_enable_federation_openid: "{{ enable_keystone_federation }}"
```

By defauly, if `enable_keystone_federation` evaluated to the boolean `False`, KA would template it to the string `"False"`, then `wsgi-keystone.conf.j2` has `{% if keystone_enable_federation_openid %}` which treats `"False"` as truthy, causing an `AnsibleUndefinedVariable` error.

KA's role already templates `keystone_enable_federation_openid` correctly, so just delete it from the chi-in-a-box defaults.