### PR TITLE
baremetal: skip disk size check for images

### DIFF
--- a/docs/operations/troubleshooting/known-issues/ironic-bare-metal.md
+++ b/docs/operations/troubleshooting/known-issues/ironic-bare-metal.md
@@ -16,4 +16,3 @@ This can happen for _many_ reasons. Check a few things:
 
 * Are there errors in the `/var/log/ironic/ironic-conductor.log`?
 * Is the node in maintenance mode? (It must be set to the "available" status for Nova to consider it.)
-* Does the node have enough space on the file system? It must have more than the space defined in the `baremetal` Nova flavor (we set this to a low value on purpose; 20Gb).

--- a/kolla/node_custom_config/nova/policy.yaml
+++ b/kolla/node_custom_config/nova/policy.yaml
@@ -60,3 +60,8 @@
 # Original: #"project_reader_api": "role:reader and project_id:%(project_id)s"
 # replace due to keystone app credential not honoring implicit roles
 "project_reader_api": "(role:reader or role:member) and project_id:%(project_id)s"
+
+# permit flavors with disk=0 to be used by non-admin users
+# used to skip nova size check for baremetal flavor.
+# Default is admin-only.
+"os_compute_api:servers:create:zero_disk_flavor": "rule:admin_or_owner"

--- a/roles/post_ironic/tasks/flavors.yml
+++ b/roles/post_ironic/tasks/flavors.yml
@@ -13,9 +13,10 @@
         "resources:VCPU": 0
         "resources:MEMORY_MB": 0
         "resources:DISK_GB": 0
-      # Needs to be greater than largest expected disk image, yet smaller than
-      # actual node capacity; we guess a low value.
-      disk: 20
+      # disk=0 skips nova's "is the disk big enough" checks entirely.
+      # if image bigger than node disk attempted, will fail when writing image.
+      # requires nova policy override, otherwise non-admins get 400 error.
+      disk: 0
       ram: 1
       vcpus: 1
   run_once: True


### PR DESCRIPTION
If users attempted to use an image larger than 20GB, they would receive a 400 error from nova, as the image size exceeded the flavor's disk. This also caused the default partion size to limit to 20gb.

This caused issues most frequently when users want to install large libraries (see CUDA, or FPGA libs), or when using RAW vs QCOW images, as nova's check looks at the file size too.

Sets the flavor's disk size to 0 gb, skipping the nova check, and set os_compute_api:servers:create:zero_disk_flavor so non-admins can use it. Policy prevented scheduler issues for KVM, but not relevant for baremetal. See https://docs.openstack.org/nova/2023.1/user/flavors.html#overview

Note: If an image is too large to fit on a baremetal node, users will see a failure when ironic tries to write the disk, instead of when submitting the POST to nova, which may delay feedback.