### PR TITLE
feat: allow ironic flavor to be updated

### DIFF
--- a/roles/post_ironic/defaults/main.yml
+++ b/roles/post_ironic/defaults/main.yml
@@ -8,6 +8,20 @@ ironic_dnsmasq_dhcp_range: "{{ ironic_provisioning_allocation_pool_start }},{{ i
 ironic_gateway_interface: "{{ network_interface | replace('_', '-') }}.{{ ironic_provisioning_network_vlan }}"
 manage_ironic_gateway_interface: false
 
+baremetal_flavor:
+  name: baremetal
+  is_public: yes
+  # set to useful value, must be smaller than smallest node disk
+  disk: 20
+  ram: 1
+  vcpus: 1
+  extra_specs: 
+    "resources:CUSTOM_BAREMETAL": 1
+    # disable scheduling by vcpu, memory, disk
+    "resources:VCPU": 0
+    "resources:MEMORY_MB": 0
+    "resources:DISK_GB": 0
+
 ironic_glance_images:
   - name: pxe_deploy_kernel
     container_format: aki

--- a/roles/post_ironic/tasks/flavors.yml
+++ b/roles/post_ironic/tasks/flavors.yml
@@ -5,7 +5,7 @@
     module_name: openstack.cloud.compute_flavor_info
     module_args:
       auth: "{{ openstack_auth }}"
-      name: baremetal
+      name: "{{ baremetal_flavor.name }}"
   register: baremetal_flavor_lookup
   run_once: True
   become: True
@@ -21,20 +21,14 @@
     module_args:
       auth: "{{ openstack_auth }}"
       state: present
-      name: baremetal
-      # Reuse existing UUID so update-via-recreate doesn't strand instances/reservations.
+      # Reuse existing ID during delete+recreate
       id: "{{ flavor_id | default(omit) }}"
-      is_public: yes
-      extra_specs:
-        "resources:CUSTOM_BAREMETAL": 1
-        "resources:VCPU": 0
-        "resources:MEMORY_MB": 0
-        "resources:DISK_GB": 0
-      # Needs to be greater than largest expected disk image, yet smaller than
-      # actual node capacity; we guess a low value.
-      disk: 20
-      ram: 1
-      vcpus: 1
+      name: "{{ baremetal_flavor.name }}"
+      is_public: "{{ baremetal_flavor.is_public }}"
+      disk: "{{ baremetal_flavor.disk }}"
+      ram: "{{ baremetal_flavor.ram }}"
+      vcpus: "{{ baremetal_flavor.vcpus }}"
+      extra_specs: "{{ baremetal_flavor.extra_specs }}"
   run_once: True
   become: True
   when: enable_ironic | bool

--- a/roles/post_ironic/tasks/flavors.yml
+++ b/roles/post_ironic/tasks/flavors.yml
@@ -1,5 +1,20 @@
 ---
+- name: Look up existing baremetal flavor
+  kolla_toolbox:
+    container_engine: "{{ kolla_container_engine }}"
+    module_name: openstack.cloud.compute_flavor_info
+    module_args:
+      auth: "{{ openstack_auth }}"
+      name: baremetal
+  register: baremetal_flavor_lookup
+  run_once: True
+  become: True
+  check_mode: false
+  when: enable_ironic | bool
+
 - name: Create baremetal flavor.
+  vars:
+    flavor_id: "{{ (baremetal_flavor_lookup.flavors | first).id }}"
   kolla_toolbox:
     container_engine: "{{ kolla_container_engine }}"
     module_name: openstack.cloud.compute_flavor
@@ -7,6 +22,8 @@
       auth: "{{ openstack_auth }}"
       state: present
       name: baremetal
+      # Reuse existing UUID so update-via-recreate doesn't strand instances/reservations.
+      id: "{{ flavor_id | default(omit) }}"
       is_public: yes
       extra_specs:
         "resources:CUSTOM_BAREMETAL": 1


### PR DESCRIPTION
two changes:
1. ansible os_flavor module will now delete+recreate flavors to update them. Update the role to preserve flavor ID, in case users reference the baremetal flavor by ID, and to avoid breaking smoke tests config (which also references by id).
2. move flavor config from task to defaults so it can be overridden.