### PR TITLE
feat: bump ironic flavor size to 100gb

### DIFF
--- a/roles/post_ironic/defaults/main.yml
+++ b/roles/post_ironic/defaults/main.yml
@@ -12,7 +12,7 @@ baremetal_flavor:
   name: baremetal
   is_public: yes
   # set to useful value, must be smaller than smallest node disk
-  disk: 20
+  disk: 100
   ram: 1
   vcpus: 1
   extra_specs: 


### PR DESCRIPTION
The smallest disk in referenceapi is 120GB. Bump the flavor size from 20GB to 100GB to allow larger images to be used. (we can argue about what the size should be).