### PR TITLE
Wip/post network skips

### DIFF
--- a/roles/post_networking/tasks/public.yml
+++ b/roles/post_networking/tasks/public.yml
@@ -3,22 +3,23 @@
 # Public net configuration
 ##########################
 
-# - name: Check public network configuration
-#   assert:
-#     that:
-#       - public_network is not false
-#       - public_network.cidr is defined
-#       - public_network.gateway_ip is defined
-#     fail_msg: |
-#       No 'public' neutron_network is defined! At least one externally-facing
-#       network should be defined, and it should be called 'public'.
-#   when:
-#     - public_network is defined
+- name: Look up existing public network
+  kolla_toolbox:
+    container_engine: "{{ kolla_container_engine }}"
+    module_name: openstack.cloud.networks_info
+    module_args:
+      auth: "{{ openstack_auth }}"
+      name: public
+  register: public_network_lookup
+  become: true
+  run_once: True
+  when:
+    - public_network is defined
 
 - name: Create public network
   kolla_toolbox:
     container_engine: "{{ kolla_container_engine }}"
-    module_name: os_network
+    module_name: openstack.cloud.network
     module_args:
       auth: "{{ openstack_auth }}"
       project: "{{ keystone_admin_project }}"
@@ -31,21 +32,34 @@
   run_once: True
   when:
     - public_network is defined
+    - (public_network_lookup.networks | default([])) | length == 0
+
+- name: Look up existing public subnet
+  kolla_toolbox:
+    container_engine: "{{ kolla_container_engine }}"
+    module_name: openstack.cloud.subnets_info
+    module_args:
+      auth: "{{ openstack_auth }}"
+      name: public-subnet
+  register: public_subnet_lookup
+  become: true
+  run_once: True
+  when:
+    - public_network.cidr is defined
 
 - name: Set fact for public allocation pool
-  set_fact:
+  ansible.builtin.set_fact:
     public_allocation_pool_start: "{{ public_network.allocation_pools[0].start | default(public_network.cidr | next_nth_usable(2)) }}"
     public_allocation_pool_end: "{{ public_network.allocation_pools[0].end | default(public_network.cidr | ipaddr('last_usable') | ipmath(-1)) }}"
   when:
     - public_network.cidr is defined
-    - public_network is defined
 
 # NOTE(jason): the os_subnet module doesn't support multiple allocation pools
 # at the moment, so only one allocation pool can be automatically created.
 - name: Create public subnet
   kolla_toolbox:
     container_engine: "{{ kolla_container_engine }}"
-    module_name: os_subnet
+    module_name: openstack.cloud.subnet
     module_args:
       auth: "{{ openstack_auth }}"
       project: "{{ keystone_admin_project }}"
@@ -59,8 +73,6 @@
       state: present
   become: true
   run_once: True
-  vars:
-    network: "{{ public_network }}"
   when:
     - public_network.cidr is defined
-    - public_network is defined
+    - (public_subnet_lookup.subnets | default([])) | length == 0

--- a/roles/post_networking/tasks/public.yml
+++ b/roles/post_networking/tasks/public.yml
@@ -10,6 +10,8 @@
     module_args:
       auth: "{{ openstack_auth }}"
       name: public
+      filters:
+        router:external: yes
   register: public_network_lookup
   become: true
   run_once: True
@@ -65,9 +67,9 @@
       project: "{{ keystone_admin_project }}"
       network_name: public
       name: public-subnet
-      cidr: "{{ network.cidr }}"
+      cidr: "{{ public_network.cidr }}"
       enable_dhcp: false
-      gateway_ip: "{{ network.gateway_ip | default(network.cidr | ipaddr('last_usable')) }}"
+      gateway_ip: "{{ public_network.gateway_ip | default(public_network.cidr | ipaddr('last_usable')) }}"
       allocation_pool_start: "{{ public_allocation_pool_start }}"
       allocation_pool_end: "{{ public_allocation_pool_end }}"
       state: present

--- a/roles/post_networking/tasks/sharednet.yml
+++ b/roles/post_networking/tasks/sharednet.yml
@@ -6,10 +6,24 @@
     - shared_network.on_demand_vlan_ranges is defined
     - shared_network.on_demand_vlan_ranges | length > 0
 
+- name: Look up existing sharednet
+  kolla_toolbox:
+    container_engine: "{{ kolla_container_engine }}"
+    module_name: openstack.cloud.networks_info
+    module_args:
+      auth: "{{ openstack_auth }}"
+      name: "{{ shared_network.sharednet.name | default(default_sharednet_name) }}"
+      filters:
+        shared: yes
+
+  register: existing_sharednet_lookup
+  become: true
+  run_once: True
+
 - name: Create shared network(s)
   kolla_toolbox:
     container_engine: "{{ kolla_container_engine }}"
-    module_name: os_network
+    module_name: openstack.cloud.network
     module_args:
       auth: "{{ openstack_auth }}"
       project: "{{ keystone_admin_project }}"
@@ -27,11 +41,23 @@
   run_once: True
   when:
     - item.sharednet is defined
+    - (existing_sharednet_lookup.networks | default([])) | length == 0
+
+- name: Look up existing sharednet subnet
+  kolla_toolbox:
+    container_engine: "{{ kolla_container_engine }}"
+    module_name: openstack.cloud.subnets_info
+    module_args:
+      auth: "{{ openstack_auth }}"
+      name: "{{ (shared_network.sharednet.name | default(default_sharednet_name)) + '-subnet' }}"
+  register: existing_sharednet_subnet_lookup
+  become: true
+  run_once: True
 
 - name: Create shared network subnet(s)
   kolla_toolbox:
     container_engine: "{{ kolla_container_engine }}"
-    module_name: os_subnet
+    module_name: openstack.cloud.subnet
     module_args:
       auth: "{{ openstack_auth }}"
       project: "{{ keystone_admin_project }}"
@@ -50,12 +76,28 @@
   when:
     - item.sharednet is defined
     - item.sharednet.enabled | default(true) | bool
+    - (existing_sharednet_subnet_lookup.subnets | default([])) | length == 0
   register: sharednet_subnets
+
+- name: Look up existing sharednet router
+  kolla_toolbox:
+    container_engine: "{{ kolla_container_engine }}"
+    module_name: openstack.cloud.routers_info
+    module_args:
+      auth: "{{ openstack_auth }}"
+      name: sharednet-router
+  register: sharednet_router_lookup
+  become: true
+  run_once: True
+  when:
+    - public_network is defined
+    - public_network.name is defined
+    - public_network.cidr is defined
 
 - name: Create NAT router for shared network(s).
   kolla_toolbox:
     container_engine: "{{ kolla_container_engine }}"
-    module_name: os_router
+    module_name: openstack.cloud.router
     module_args:
       auth: "{{ openstack_auth }}"
       project: "{{ keystone_admin_project }}"
@@ -71,3 +113,4 @@
     - public_network is defined
     - public_network.name is defined
     - public_network.cidr is defined
+    - (sharednet_router_lookup.routers | default([])) | length == 0

--- a/roles/post_networking/tasks/sharednet.yml
+++ b/roles/post_networking/tasks/sharednet.yml
@@ -1,6 +1,6 @@
 ---
 - name: Set fact for sharednet segmentation id
-  set_fact:
+  ansible.builtin.set_fact:
     sharednet_segmentation_id: "{{ (shared_network.on_demand_vlan_ranges[0].split(':')[0] | int) + 1 }}"
   when:
     - shared_network.on_demand_vlan_ranges is defined
@@ -15,10 +15,11 @@
       name: "{{ shared_network.sharednet.name | default(default_sharednet_name) }}"
       filters:
         shared: yes
-
   register: existing_sharednet_lookup
   become: true
   run_once: True
+  when:
+    - shared_network.sharednet is defined
 
 - name: Create shared network(s)
   kolla_toolbox:
@@ -53,6 +54,8 @@
   register: existing_sharednet_subnet_lookup
   become: true
   run_once: True
+  when:
+    - shared_network.sharednet is defined
 
 - name: Create shared network subnet(s)
   kolla_toolbox:

--- a/roles/post_networking/tasks/sharednet.yml
+++ b/roles/post_networking/tasks/sharednet.yml
@@ -18,8 +18,6 @@
   register: existing_sharednet_lookup
   become: true
   run_once: True
-  when:
-    - shared_network.sharednet is defined
 
 - name: Create shared network(s)
   kolla_toolbox:
@@ -54,8 +52,6 @@
   register: existing_sharednet_subnet_lookup
   become: true
   run_once: True
-  when:
-    - shared_network.sharednet is defined
 
 - name: Create shared network subnet(s)
   kolla_toolbox:


### PR DESCRIPTION
Somewhere between version 2.0.0 and 2.2.0 (in 2023.1), the ansible openstack.cloud collection changed behavor:
When applying a network, subnet, or router "create or update" task, it would evaluate as "create or skip", instead of updating.

This means that site-config drifted from the deployed config over time. More recent version correctly updates, but this behavior change can break the post-deploy execution, or destructively change a production network.

This PR introduces a "check and create if missing" logic, to restore the old behavior.
Once we clean up how `neutron_networks` is used to template these, it should be tractable to migrate to the intended "update if different" flow.