### PR TITLE
override tunelo policy for backwards compat

### DIFF
--- a/kolla/node_custom_config/tunelo/policy.yaml
+++ b/kolla/node_custom_config/tunelo/policy.yaml
@@ -1,0 +1,22 @@
+# Retrieve channel details
+# GET  /channels
+# GET  /channels/{channel_uuid}
+#"channel:get": "role:admin or project_id:%(project_id)s"
+
+# Stopgap: right now, Doni creates all channels owned by the doni service user.
+# Users will not be able to read channels created on their behalf
+# Override the policy to allow current behavor: anyone authenticated can read.
+"channel:get": "@"
+
+# Create a channel
+# POST  /channels
+#"channel:create": "role:admin or project_id:%(project_id)s"
+
+# Update a channel
+# PATCH  /channels/{channel_uuid}
+# PUT  /channels/{channel_uuid}
+#"channel:update": "role:admin or project_id:%(project_id)s"
+
+# Delete a channel
+# DELETE  /channels/{channel_uuid}
+#"channel:delete": "role:admin or project_id:%(project_id)s"


### PR DESCRIPTION
Override tunelo read policy to make https://github.com/ChameleonCloud/tunelo/pull/28 backwards compatible.