### PR TITLE
blazar: expose blazar_enable_flavor_reservation

### DIFF
--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -83,6 +83,7 @@ blazar_network_polling_monitor: true
 blazar_network_polling_monitor_dry_run: true
 blazar_randomize_hosts: true
 blazar_cleaning_time_minutes: 5
+blazar_enable_host_reservation: "{{ enable_nova | bool }}"
 
 # enable to use https://github.com/ChameleonCloud/nova/pull/9
 # workaround for https://bugs.launchpad.net/nova/+bug/1542491

--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -84,6 +84,8 @@ blazar_network_polling_monitor_dry_run: true
 blazar_randomize_hosts: true
 blazar_cleaning_time_minutes: 5
 blazar_enable_host_reservation: "{{ enable_nova | bool }}"
+blazar_enable_flavor_reservation: false
+blazar_flavor_reservation_trait: blazar_flavor_reservation
 
 # enable to use https://github.com/ChameleonCloud/nova/pull/9
 # workaround for https://bugs.launchpad.net/nova/+bug/1542491

--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -47,6 +47,7 @@ backup_location: "{{ mariabackup_location if enable_mariabackup | bool else mysq
 # Blazar
 enable_blazar: yes
 enable_blazar_allocation_enforcement: no
+enable_blazar_lease_duration_enforcement: no
 blazar_project_enforcement_id: charge_code
 # When to send lease notification email
 blazar_minutes_before_end_lease: 2880

--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -87,6 +87,8 @@ blazar_cleaning_time_minutes: 5
 blazar_enable_host_reservation: "{{ enable_nova | bool }}"
 blazar_enable_flavor_reservation: false
 blazar_flavor_reservation_trait: blazar_flavor_reservation
+blazar_filter_vm_hosts: true
+blazar_filter_ironic_hosts: true
 
 # enable to use https://github.com/ChameleonCloud/nova/pull/9
 # workaround for https://bugs.launchpad.net/nova/+bug/1542491

--- a/kolla/node_custom_config/blazar.conf
+++ b/kolla/node_custom_config/blazar.conf
@@ -6,8 +6,15 @@ cleaning_time = {{ blazar_cleaning_time_minutes }}
 {# note: important to preserve newline after this #}
 exempt_projects = {% for project_id in blazar_usage_project_exemptions %}{{ project_id }}{% if not loop.last %},{% endif %}{% endfor %}
 
+{% set filters = [] %}
+{% if enable_blazar_lease_duration_enforcement | bool %}
+{%   set _ = filters.append("MaxLeaseDurationFilter") %}
+{% endif %}
 {% if enable_blazar_allocation_enforcement | bool %}
-enabled_filters = ExternalServiceFilter
+{%   set _ = filters.append("ExternalServiceFilter") %}
+{% endif %}
+enabled_filters = {{ filters | join(", ") }}
+
 {% if blazar_external_service_endpoint is defined %}
 external_service_base_endpoint = {{ blazar_external_service_endpoint }}
 {% endif %}
@@ -19,9 +26,6 @@ external_service_check_update_endpoint = {{ blazar_external_service_check_update
 {% endif %}
 {% if blazar_external_service_on_end_endpoint is defined %}
 external_service_on_end_endpoint = {{ blazar_external_service_on_end_endpoint }}
-{% endif %}
-{% else %}
-enabled_filters = MaxLeaseDurationFilter
 {% endif %}
 max_lease_duration = {{ blazar_default_max_lease_duration }}
 reservation_extension_window = {{ blazar_default_reservation_extension_window }}

--- a/kolla/node_custom_config/blazar.conf
+++ b/kolla/node_custom_config/blazar.conf
@@ -31,7 +31,7 @@ region_name = {{ openstack_region_name }}
 
 [manager]
 {# note: important to preserve newline after this #}
-plugins = network.plugin,virtual.floatingip.plugin{% if blazar_enable_host_reservation | bool %},physical.host.plugin{% endif %}{% if enable_zun | bool %},device.plugin{% endif %}
+plugins = network.plugin,virtual.floatingip.plugin{% if blazar_enable_host_reservation | bool %},physical.host.plugin{% endif %}{% if enable_zun | bool %},device.plugin{% endif %}{% if blazar_enable_flavor_reservation | bool %},flavor.instance.plugin{% endif %}
 
 minutes_before_end_lease = {{ blazar_minutes_before_end_lease }}
 
@@ -82,6 +82,12 @@ retry_allocation_without_defaults = {{ blazar_network_retry_without_default_reso
 default_resource_properties = {{ blazar_network_default_resource_properties }}
 enable_polling_monitor = {{ blazar_network_polling_monitor}}
 enable_polling_monitor_dry_run = {{ blazar_network_polling_monitor_dry_run }}
+
+[flavor:instance]
+randomize_host_selection = {{ blazar_randomize_hosts | bool }}
+# Note this configures if email is sent. Email relay uses host config.
+before_end = email
+placement_reservation_permitted_trait = {{ blazar_flavor_reservation_trait }}
 
 [api]
 allocation_extras = {{ blazar_api_allocation_extras }}

--- a/kolla/node_custom_config/blazar.conf
+++ b/kolla/node_custom_config/blazar.conf
@@ -31,7 +31,7 @@ region_name = {{ openstack_region_name }}
 
 [manager]
 {# note: important to preserve newline after this #}
-plugins = network.plugin,virtual.floatingip.plugin{% if enable_nova | bool %},physical.host.plugin{% endif %}{% if enable_zun | bool %},device.plugin{% endif %}
+plugins = network.plugin,virtual.floatingip.plugin{% if blazar_enable_host_reservation | bool %},physical.host.plugin{% endif %}{% if enable_zun | bool %},device.plugin{% endif %}
 
 minutes_before_end_lease = {{ blazar_minutes_before_end_lease }}
 
@@ -64,6 +64,7 @@ enable_polling_monitor_dry_run = {{ blazar_physical_polling_monitor_dry_run }}
 retry_allocation_without_defaults = {{ blazar_host_retry_without_default_resources | bool }}
 default_resource_properties = {{ blazar_host_default_resource_properties }}
 {% endif %}
+allow_reservation = {{ blazar_enable_host_reservation | bool }}
 randomize_host_selection = {{ blazar_randomize_hosts | bool }}
 
 {% if enable_zun | bool %}

--- a/kolla/node_custom_config/blazar.conf
+++ b/kolla/node_custom_config/blazar.conf
@@ -70,6 +70,7 @@ default_resource_properties = {{ blazar_host_default_resource_properties }}
 {% endif %}
 allow_reservation = {{ blazar_enable_host_reservation | bool }}
 randomize_host_selection = {{ blazar_randomize_hosts | bool }}
+filter_vm_hosts = {{ blazar_filter_vm_hosts | bool }}
 
 {% if enable_zun | bool %}
 [device]
@@ -92,6 +93,7 @@ randomize_host_selection = {{ blazar_randomize_hosts | bool }}
 # Note this configures if email is sent. Email relay uses host config.
 before_end = email
 placement_reservation_permitted_trait = {{ blazar_flavor_reservation_trait }}
+filter_ironic_hosts = {{ blazar_filter_ironic_hosts | bool }}
 
 [api]
 allocation_extras = {{ blazar_api_allocation_extras }}

--- a/kolla/node_custom_config/horizon/custom_local_settings
+++ b/kolla/node_custom_config/horizon/custom_local_settings
@@ -147,20 +147,23 @@ WEBSSO_DEFAULT_REDIRECT_LOGOUT = '{{ keystone_public_url }}/redirect_uri?logout=
 
 {% endif %}
 
+# If we don't have VMs configured (i.e. no flavor res), then hide VM-only options in the UI
+CHAMELEON_BAREMETAL_ONLY = {{ not (blazar_enable_flavor_reservation | bool) }}
+
 # A dictionary of settings which can be used to provide the default values for
 # properties found in the Launch Instance modal.
 LAUNCH_INSTANCE_DEFAULTS = {
-    'config_drive': False,
+    'config_drive': True,
     'enable_scheduler_hints': True,
     'disable_image': False,
-    'disable_instance_snapshot': True,
-    'disable_volume': True,
-    'disable_volume_snapshot': True,
-    'create_volume': False,
-    'enable_metadata': False,
+    'disable_instance_snapshot': CHAMELEON_BAREMETAL_ONLY,
+    'disable_volume': CHAMELEON_BAREMETAL_ONLY,
+    'disable_volume_snapshot': CHAMELEON_BAREMETAL_ONLY,
+    'create_volume': not CHAMELEON_BAREMETAL_ONLY,
+    'enable_metadata': not CHAMELEON_BAREMETAL_ONLY,
     'enable_net_ports': True,
-    'enable_secgroups': False,
-    'enable_servergroups': False,
+    'enable_secgroups': not CHAMELEON_BAREMETAL_ONLY,
+    'enable_servergroups': not CHAMELEON_BAREMETAL_ONLY,
     'default_flavor_name': 'baremetal',
 }
 

--- a/kolla/node_custom_config/horizon/custom_local_settings
+++ b/kolla/node_custom_config/horizon/custom_local_settings
@@ -202,3 +202,6 @@ X_FRAME_OPTIONS = 'SAMEORIGIN'
 
 # disable usage report on overview page
 OPENSTACK_USE_SIMPLE_TENANT_USAGE = False
+
+# In instance launch, only show reserved flavors
+OPENSTACK_SHOW_ONLY_RESERVED_FLAVORS = {{ blazar_enable_flavor_reservation | bool}},

--- a/kolla/node_custom_config/horizon/custom_local_settings
+++ b/kolla/node_custom_config/horizon/custom_local_settings
@@ -95,6 +95,10 @@ OPENSTACK_BLAZAR_HOST_RESERVATION = {
   'url_format': '{{ blazar_host_url_format }}',
 }
 OPENSTACK_BLAZAR_DEFAULT_COMPUTE_NODE_TYPE = '{{ blazar_default_compute_node_type }}'
+OPENSTACK_BLAZAR_FLAVOR_RESERVATION = {
+  "enabled": {{ blazar_enable_flavor_reservation | bool}},
+  "blazar_flavor_reservation_trait": '{{ blazar_flavor_reservation_trait }}',
+}
 {% endif %}
 
 # horizon themes are represented as a tuple of name, label, and path

--- a/kolla/node_custom_config/horizon/custom_local_settings
+++ b/kolla/node_custom_config/horizon/custom_local_settings
@@ -91,7 +91,7 @@ OPENSTACK_BLAZAR_DEVICE_RESERVATION = {
   'enabled': {{ enable_zun | bool }},
 }
 OPENSTACK_BLAZAR_HOST_RESERVATION = {
-  'enabled': {{ enable_nova | bool }},
+  'enabled': {{ blazar_enable_host_reservation | bool }},
   'url_format': '{{ blazar_host_url_format }}',
 }
 OPENSTACK_BLAZAR_DEFAULT_COMPUTE_NODE_TYPE = '{{ blazar_default_compute_node_type }}'

--- a/kolla/node_custom_config/placement/policy.yaml
+++ b/kolla/node_custom_config/placement/policy.yaml
@@ -1,0 +1,2 @@
+"placement:resource_providers:traits:list": "@"
+"placement:resource_providers:list": "@"


### PR DESCRIPTION
Pulls in changes for dev@tacc hybrid site.

The only configuration in a "diff" between stable/2023.1 and what was deployed on def@tacc was:

```
#kolla/defaults.yml
blazar_enable_flavor_reservation: false
```

and
```
#kolla/node_custom_config/blazar.conf
...{% if blazar_enable_flavor_reservation | bool %},flavor.instance.plugin{% endif %}
```

However, I have also cherry-picked https://github.com/ChameleonCloud/chi-in-a-box/pull/318 on top of that diff, and attempted to rebase into a logical set of commits.
