### PR TITLE
post-deploy networks fixups

### DIFF
--- a/roles/post_networking/defaults/main.yml
+++ b/roles/post_networking/defaults/main.yml
@@ -23,7 +23,7 @@ shared_networks: "{{ neutron_networks | selectattr('sharednet', 'defined') | lis
 shared_network: "{{ shared_networks[0] if shared_networks }}"
 
 default_sharednet_name: sharednet1
-default_sharednet_cidr: 10.0.0.1/24
+default_sharednet_cidr: 10.0.0.0/24
 
 ##############################################################################
 # Edge networks: tunelo-calico (wireguard IPAM) + caliconet (container IPs)

--- a/roles/post_networking/defaults/main.yml
+++ b/roles/post_networking/defaults/main.yml
@@ -1,9 +1,24 @@
+# This file handles configuration of neutron "logical" networks and mapping to 
+# neutron physical networks.  The complexity is due to backwards compatibility
+# concerns, the plan is to clean this up during the 2023.1 -> 2025.1 migration.
+
+# `public_network` here is the neutron physical network config which contains a
+# config entry for the public logical network. See above for why this is messy :(
 public_networks: "{{ neutron_networks | selectattr('public', 'defined') | list }}"
-# This is added for backwards compatibility
+# Entries literally named "public" are also accepted, for backwards compatibility
 named_public_networks: "{{ neutron_networks | selectattr('name', 'equalto', 'public') | list }}"
 all_public_networks: "{{ public_networks + named_public_networks }}"
 public_network: "{{ all_public_networks[0] if all_public_networks }}"
+# Effective public subnet config (cidr, gateway_ip, allocation_pools).
+# For backwards compatibility, this takes values listed under `physnet.public.value`,
+# put also `physnet.value` as previously the subnet config was top level.
+public_conf: "{{ (public_network | combine(public_network.public | default({}, true))) if public_network is mapping else {} }}"
 
+public_network_name: public
+public_subnet_name: public-subnet
+
+# Subnet parameters for sharednet live inside the `sharednet:` dict itself
+# (see sharednet.yml), unlike public_conf there is no top-level fallback.
 shared_networks: "{{ neutron_networks | selectattr('sharednet', 'defined') | list }}"
 shared_network: "{{ shared_networks[0] if shared_networks }}"
 

--- a/roles/post_networking/tasks/admin_router.yml
+++ b/roles/post_networking/tasks/admin_router.yml
@@ -16,9 +16,9 @@
       name: "{{ admin_router_name }}"
       interfaces:
         - "{{ caliconet_subnet_name }}"
-      network: "{{ public_network.name }}"
+      network: "{{ public_network_name }}"
       external_fixed_ips:
-        - subnet: public-subnet
+        - subnet: "{{ public_subnet_name }}"
       state: present
   become: true
   run_once: true

--- a/roles/post_networking/tasks/public.yml
+++ b/roles/post_networking/tasks/public.yml
@@ -9,14 +9,14 @@
     module_name: openstack.cloud.networks_info
     module_args:
       auth: "{{ openstack_auth }}"
-      name: public
+      name: "{{ public_network_name }}"
       filters:
         router:external: yes
   register: public_network_lookup
   become: true
   run_once: True
   when:
-    - public_network is defined
+    - public_network is mapping
 
 - name: Create public network
   kolla_toolbox:
@@ -25,15 +25,15 @@
     module_args:
       auth: "{{ openstack_auth }}"
       project: "{{ keystone_admin_project }}"
-      name: public
+      name: "{{ public_network_name }}"
       provider_network_type: flat
-      provider_physical_network: public
+      provider_physical_network: "{{ public_network.name }}"
       external: yes
       state: present
   become: true
   run_once: True
   when:
-    - public_network is defined
+    - public_network is mapping
     - (public_network_lookup.networks | default([])) | length == 0
 
 - name: Look up existing public subnet
@@ -42,19 +42,19 @@
     module_name: openstack.cloud.subnets_info
     module_args:
       auth: "{{ openstack_auth }}"
-      name: public-subnet
+      name: "{{ public_subnet_name }}"
   register: public_subnet_lookup
   become: true
   run_once: True
   when:
-    - public_network.cidr is defined
+    - public_conf.cidr is defined
 
 - name: Set fact for public allocation pool
   ansible.builtin.set_fact:
-    public_allocation_pool_start: "{{ public_network.allocation_pools[0].start | default(public_network.cidr | next_nth_usable(2)) }}"
-    public_allocation_pool_end: "{{ public_network.allocation_pools[0].end | default(public_network.cidr | ipaddr('last_usable') | ipmath(-1)) }}"
+    public_allocation_pool_start: "{{ public_conf.allocation_pools[0].start | default(public_conf.cidr | next_nth_usable(2)) }}"
+    public_allocation_pool_end: "{{ public_conf.allocation_pools[0].end | default(public_conf.cidr | ipaddr('last_usable') | ipmath(-1)) }}"
   when:
-    - public_network.cidr is defined
+    - public_conf.cidr is defined
 
 # NOTE(jason): the os_subnet module doesn't support multiple allocation pools
 # at the moment, so only one allocation pool can be automatically created.
@@ -65,16 +65,16 @@
     module_args:
       auth: "{{ openstack_auth }}"
       project: "{{ keystone_admin_project }}"
-      network_name: public
-      name: public-subnet
-      cidr: "{{ public_network.cidr }}"
+      network_name: "{{ public_network_name }}"
+      name: "{{ public_subnet_name }}"
+      cidr: "{{ public_conf.cidr }}"
       enable_dhcp: false
-      gateway_ip: "{{ public_network.gateway_ip | default(public_network.cidr | ipaddr('last_usable')) }}"
+      gateway_ip: "{{ public_conf.gateway_ip | default(public_conf.cidr | ipaddr('last_usable')) }}"
       allocation_pool_start: "{{ public_allocation_pool_start }}"
       allocation_pool_end: "{{ public_allocation_pool_end }}"
       state: present
   become: true
   run_once: True
   when:
-    - public_network.cidr is defined
+    - public_conf.cidr is defined
     - (public_subnet_lookup.subnets | default([])) | length == 0

--- a/roles/post_networking/tasks/sharednet.yml
+++ b/roles/post_networking/tasks/sharednet.yml
@@ -89,9 +89,9 @@
   become: true
   run_once: True
   when:
-    - public_network is defined
+    - public_network is mapping
     - public_network.name is defined
-    - public_network.cidr is defined
+    - public_conf.cidr is defined
 
 - name: Create NAT router for shared network(s).
   kolla_toolbox:
@@ -102,14 +102,14 @@
       project: "{{ keystone_admin_project }}"
       name: sharednet-router
       interfaces: "{{ sharednet_subnets.results | selectattr('subnet', 'defined') | map(attribute='subnet') | map(attribute='name') | list }}"
-      network: "{{ public_network.name }}"
+      network: "{{ public_network_name }}"
       external_fixed_ips:
-        - subnet: "public-subnet"
+        - subnet: "{{ public_subnet_name }}"
   become: true
   run_once: True
   when:
     - sharednet_subnets is defined
-    - public_network is defined
+    - public_network is mapping
     - public_network.name is defined
-    - public_network.cidr is defined
+    - public_conf.cidr is defined
     - (sharednet_router_lookup.routers | default([])) | length == 0

--- a/roles/post_networking/tasks/sharednet.yml
+++ b/roles/post_networking/tasks/sharednet.yml
@@ -93,7 +93,12 @@
     - public_network.name is defined
     - public_conf.cidr is defined
 
+# To ensure we have the router interface in sharednet, use output of either 
+# lookup or create.
 - name: Create NAT router for shared network(s).
+  vars:
+    existing_subnets: "{{ existing_sharednet_subnet_lookup.subnets | default([]) }}"
+    created_subnets: "{{ sharednet_subnets.results | default([]) | selectattr('subnet', 'defined') | map(attribute='subnet') | list }}"
   kolla_toolbox:
     container_engine: "{{ kolla_container_engine }}"
     module_name: openstack.cloud.router
@@ -101,14 +106,13 @@
       auth: "{{ openstack_auth }}"
       project: "{{ keystone_admin_project }}"
       name: sharednet-router
-      interfaces: "{{ sharednet_subnets.results | selectattr('subnet', 'defined') | map(attribute='subnet') | map(attribute='name') | list }}"
+      interfaces: "{{ (existing_subnets + created_subnets) | map(attribute='name') | list }}"
       network: "{{ public_network_name }}"
       external_fixed_ips:
         - subnet: "{{ public_subnet_name }}"
   become: true
   run_once: True
   when:
-    - sharednet_subnets is defined
     - public_network is mapping
     - public_network.name is defined
     - public_conf.cidr is defined

--- a/site-config.example/defaults.yml
+++ b/site-config.example/defaults.yml
@@ -115,35 +115,38 @@ kolla_internal_vip_address: "10.10.10.254"
 # bridge_name: name of openvswitch bridge mapped to the physical network
 # external_interface: what interface on the host to attach to the ovs bridge
 
-# cidr: the address and netmask for the subnet to be associated with the network.
-#   If using a gateway, it must match the configuration for that gateway.
-# Gateway IP: IP address of external router
-# allocation_pools: Define the address range(s) to hand out on this network.
-#   For the public network, ensure this does NOT overlap with your API addresses defined above!
-
 # on_demand_vlan_ranges: list of vlan IDs that can be automatically assigned on network creation
 # reservable_vlan_ranges: list of vlan IDs that can be reserved via Blazar. it should NOT overlap with
 #   the on_demand_vlan_ranges. Currently a placeholder, as reservable vlans are still created manually.
 
+# public: marks this physical network as the one carrying the external "public" neutron
+#   network, used for router external interfaces and floating IP addresses.
+#   cidr: the address and netmask for the subnet to be associated with the network.
+#   gateway_ip: IP address of external router
+#   allocation_pools: Define the address range(s) to hand out on this network.
+#     Ensure this does NOT overlap with your API addresses defined above!
+
 # sharednet: l3 tenant network used as the "default", for users who don't need isolation.
 #   post-deploy will create a neutron router attached to this network, and NAT traffic from it to the public network.
+#   Takes the same nested cidr/allocation_pools parameters as public.
+
+# The public and sharednet keys may be placed on the same entry to run both over a
+# single physical network (flat public + tagged vlans on one bridge).
 
 neutron_networks:
-- name: public
+- name: physnet1
   bridge_name: br-ex
   # external_interface: <neutron_public_physnet_interface>
-  # cidr: 192.5.87.0/24
-  # gateway_ip: 192.5.87.1
-  # allocation_pools:
-  #   - start: 192.5.87.10
-  #     end: 192.5.87.250
-- name: physnet1
-  bridge_name: br-physnet1
-  # external_interface: <neutron_tenant_physnet_interface>
   on_demand_vlan_ranges:
     - 200:250
   reservable_vlan_ranges:
     - 251:300
+  # public:
+  #   cidr: 192.5.87.0/24
+  #   gateway_ip: 192.5.87.1
+  #   allocation_pools:
+  #     - start: 192.5.87.10
+  #       end: 192.5.87.250
   sharednet:
     # cidr: 10.200.10.0/22
     # allocation_pools:


### PR DESCRIPTION
support specifying "public" and "sharednet" on the same neutron physnet.
Also fixes issues when creating sharednet and fip router.

Allows the following config style:

```
neutron_networks:
  - name: physnet1
    bridge_name: br-ex
    external_interface: veth-neutron
    on_demand_vlan_ranges:
     - 200:250
    reservable_vlan_ranges:
     - 251:300
    public:
      cidr: 192.5.87.0/24
      gateway_ip: 192.5.87.1
      allocation_pools:
      - start: 192.5.87.10
        end: 192.5.87.250
    sharednet:
     cidr: 10.200.10.0/22
     allocation_pools:
     - start: 10.200.10.20
       end: 10.200.12.21
 ```