### PR TITLE
expose config flags for hybrid sites

### DIFF
--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -84,6 +84,8 @@ blazar_network_polling_monitor_dry_run: true
 blazar_randomize_hosts: true
 blazar_cleaning_time_minutes: 5
 
+blazar_enable_flavor_reservation: false
+
 # enable to use https://github.com/ChameleonCloud/nova/pull/9
 # workaround for https://bugs.launchpad.net/nova/+bug/1542491
 use_blazar_prefilter: false

--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -415,3 +415,8 @@ chameleon_vendordata_read_timeout: 10
 
 #M.S. 2026/08/19 Disable proxysql until hammers and periodic tasks are updated
 enable_proxysql: false
+
+# baremetal site default flags
+chameleon_enable_baremetal: true
+chameleon_enable_vms: false
+chameleon_hide_security_groups: true

--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -70,6 +70,8 @@ blazar_api_allocation_extras: user_name
 blazar_host_default_resource_properties: '["=", "\$node_type", "compute_skylake"]'
 blazar_host_retry_without_default_resources: yes
 blazar_enable_plugin_network: yes
+blazar_enable_plugin_flavor: no
+blazar_flavor_filter_ironic_hosts: yes
 blazar_network_default_resource_properties: '["=", "\$stitch_provider", "none"]'
 blazar_network_retry_without_default_resources: no
 blazar_floatingip_reservation_network_regex: "[pP]ublic"
@@ -83,8 +85,6 @@ blazar_network_polling_monitor: true
 blazar_network_polling_monitor_dry_run: true
 blazar_randomize_hosts: true
 blazar_cleaning_time_minutes: 5
-
-blazar_enable_flavor_reservation: false
 
 # enable to use https://github.com/ChameleonCloud/nova/pull/9
 # workaround for https://bugs.launchpad.net/nova/+bug/1542491

--- a/kolla/node_custom_config/blazar.conf
+++ b/kolla/node_custom_config/blazar.conf
@@ -31,7 +31,7 @@ region_name = {{ openstack_region_name }}
 
 [manager]
 {# note: important to preserve newline after this #}
-plugins = network.plugin,virtual.floatingip.plugin{% if enable_nova | bool %},physical.host.plugin{% endif %}{% if enable_zun | bool %},device.plugin{% endif %}
+plugins = network.plugin,virtual.floatingip.plugin{% if enable_nova | bool %},physical.host.plugin{% endif %}{% if enable_zun | bool %},device.plugin{% endif %}{% if blazar_enable_plugin_flavor | bool %},flavor.instance.plugin{% endif %}
 
 minutes_before_end_lease = {{ blazar_minutes_before_end_lease }}
 
@@ -81,6 +81,10 @@ retry_allocation_without_defaults = {{ blazar_network_retry_without_default_reso
 default_resource_properties = {{ blazar_network_default_resource_properties }}
 enable_polling_monitor = {{ blazar_network_polling_monitor}}
 enable_polling_monitor_dry_run = {{ blazar_network_polling_monitor_dry_run }}
+
+[flavor:instance]
+# Keep flavor reservations off ironic hosts, which matters on hybrid sites.
+filter_ironic_hosts = {{ blazar_flavor_filter_ironic_hosts | bool }}
 
 [api]
 allocation_extras = {{ blazar_api_allocation_extras }}

--- a/kolla/node_custom_config/horizon/_9999-custom-settings.py
+++ b/kolla/node_custom_config/horizon/_9999-custom-settings.py
@@ -198,3 +198,7 @@ X_FRAME_OPTIONS = 'SAMEORIGIN'
 
 # disable usage report on overview page
 OPENSTACK_USE_SIMPLE_TENANT_USAGE = False
+
+CHAMELEON_ENABLE_BAREMETAL = {{ chameleon_enable_baremetal | bool }}
+CHAMELEON_ENABLE_VMS = {{ chameleon_enable_vms | bool }}
+CHAMELEON_HIDE_SECURITY_GROUPS = {{ chameleon_hide_security_groups | bool }}

--- a/kolla/node_custom_config/horizon/_9999-custom-settings.py
+++ b/kolla/node_custom_config/horizon/_9999-custom-settings.py
@@ -90,6 +90,9 @@ OPENSTACK_BLAZAR_FLOATINGIP_RESERVATION = {
 OPENSTACK_BLAZAR_DEVICE_RESERVATION = {
   'enabled': {{ enable_zun | bool }},
 }
+OPENSTACK_BLAZAR_FLAVOR_RESERVATION = {
+  'enabled': {{ blazar_enable_flavor_reservation | bool }},
+}
 OPENSTACK_BLAZAR_HOST_RESERVATION = {
   'enabled': {{ enable_nova | bool }},
   'url_format': '{{ blazar_host_url_format }}',

--- a/kolla/node_custom_config/horizon/_9999-custom-settings.py
+++ b/kolla/node_custom_config/horizon/_9999-custom-settings.py
@@ -91,7 +91,7 @@ OPENSTACK_BLAZAR_DEVICE_RESERVATION = {
   'enabled': {{ enable_zun | bool }},
 }
 OPENSTACK_BLAZAR_FLAVOR_RESERVATION = {
-  'enabled': {{ blazar_enable_flavor_reservation | bool }},
+  'enabled': {{ blazar_enable_plugin_flavor | bool }},
 }
 OPENSTACK_BLAZAR_HOST_RESERVATION = {
   'enabled': {{ enable_nova | bool }},


### PR DESCRIPTION
Adds config flags for enabling or disabling the blazar flavor plugin, and for the hybrid site UI customizations.