### PR TITLE
neutron-ovs: stop overriding bridge_mappings

### DIFF
--- a/kolla/node_custom_config/neutron/openvswitch_agent.ini
+++ b/kolla/node_custom_config/neutron/openvswitch_agent.ini
@@ -2,13 +2,3 @@
 [agent]
 tunnel_types =
 {% endif %}
-
-[ovs]
-{% if inventory_hostname in groups["network"] or (inventory_hostname in groups["compute"] and computes_need_external_bridge | bool ) %}
-{# DEPRECATED: neutron_ovs_bridge_mappings still takes priority if in use #}
-{% if neutron_ovs_bridge_mappings is defined %}
-bridge_mappings = {{ neutron_ovs_bridge_mappings }}
-{% elif neutron_networks is defined %}
-bridge_mappings = {% for config in neutron_networks %}{{ config.name }}:{{ config.bridge_name }}{% if not loop.last %},{% endif %}{% endfor %}
-{% endif %}
-{% endif %}


### PR DESCRIPTION
In kolla-ansible 70f2ae8e6, we made neutron_physical_networks set from neutron_networks[].name. This makes upstream's openvswitch_agent.ini.j2 render the same bridge_mappings that our override used to, so it can now be dropped.

This also removes neutron_ovs_bridge_mappings, as it was long deprecated and chameleon-only, and wasn't useful by itself.

Sites needing to override the bridge mappings per host should set neutron_physical_networks, neutron_bridge_name, and neutron_external_interface, matching upstream.