### PR TITLE
fix console for nova vms.

### DIFF
--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -300,8 +300,7 @@ neutron_wireguard_create_hub_in_root_netns: True
 enable_nova: yes
 enable_nova_serialconsole_proxy: yes
 nova_compute_virt_type: kvm
-# We are not using any VNC consoles; the serialproxy is not considered a 'nova_console'
-nova_console: none
+
 # We override the endpoints to not include %(tenant_id)s placeholder.
 # Blazar in particular needs this to not be scoped to the tenant because when
 # it tries to perform actions on behalf of a user, it uses a different tenant


### PR DESCRIPTION
Setting nova_console=none is not needed in 2025.1, nova already tries novnc, spice, serial, none, in order. Kolla-ansible sets the config correctly, disabling novnc for the ironic compute agent.

Just deleting this line makes the console work for both vms and baremetal instances.