### PR TITLE
add toggle for nova blazar reservation hint enforcement

### DIFF
--- a/kolla/defaults.yml
+++ b/kolla/defaults.yml
@@ -89,6 +89,10 @@ blazar_cleaning_time_minutes: 5
 # enable to use https://github.com/ChameleonCloud/nova/pull/9
 # workaround for https://bugs.launchpad.net/nova/+bug/1542491
 use_blazar_prefilter: false
+# If true, prefilter will reject any scheduling request without a reservation hint.
+# Turn off to permit scheduling instances onto non-blazar hosts
+# Turn off to permit flavor reservations at all # TODO fix this.
+blazar_prefilter_require_reservation_hint: true
 
 # Cinder
 enable_cinder: no

--- a/kolla/node_custom_config/nova.conf
+++ b/kolla/node_custom_config/nova.conf
@@ -81,7 +81,7 @@ max_attempts = 50
 discover_hosts_in_cells_interval = 120
 
 {% if use_blazar_prefilter | bool %}
-blazar_reservation_required = True
+blazar_reservation_required = {{ blazar_prefilter_require_reservation_hint | bool }}
 use_blazar_reservation_prefilter = True
 {% endif %}
 

--- a/site-config.example/defaults.yml
+++ b/site-config.example/defaults.yml
@@ -213,3 +213,15 @@ neutron_networks:
 #       community_string: "{{ dell_switch_community_string }}"
 #     ngs_config:
 #       fast_cli: True
+
+######################
+# Blazar configuration
+######################
+
+# Use the Blazar scheduler prefilter instead of BlazarFilter.
+# use_blazar_prefilter: false
+
+# Reject scheduling requests that carry no physical:host reservation hint.
+# Set false on hybrid sites: a VM launched from a flavor reservation carries
+# its reservation in the flavor and sends no hint.
+# blazar_prefilter_require_reservation_hint: true


### PR DESCRIPTION
The hybrid site needs the blazar prefilter not to enforce reservation hints, because flavor reservations don't pass one.